### PR TITLE
Stepper Lock Delay Pull Request

### DIFF
--- a/config.h
+++ b/config.h
@@ -56,15 +56,6 @@
 #define SPINDLE_DIRECTION_PORT PORTB
 #define SPINDLE_DIRECTION_BIT 5
 
-// This parameter sets the delay time before disabling the steppers after the final block of movement.
-// A short delay ensures the steppers come to a complete stop and the residual inertial force in the 
-// CNC axes don't cause the axes to drift off position. This is particularly important when manually 
-// entering g-code into grbl, i.e. locating part zero or simple manual machining. If the axes drift,
-// grbl has no way to know this has happened, since stepper motors are open-loop control. Depending
-// on the machine, this parameter may need to be larger or smaller than the default time.
-// NOTE: If defined 0, the delay will not be compiled.
-#define STEPPER_IDLE_LOCK_TIME 25 // (milliseconds) - Integer >= 0
-
 // The temporal resolution of the acceleration management subsystem. Higher number give smoother
 // acceleration but may impact performance.
 // NOTE: Increasing this parameter will help any resolution related issues, especially with machines 

--- a/settings.c
+++ b/settings.c
@@ -54,6 +54,7 @@ typedef struct {
 #define DEFAULT_ACCELERATION (DEFAULT_FEEDRATE*60*60/10.0) // mm/min^2
 #define DEFAULT_JUNCTION_DEVIATION 0.05 // mm
 #define DEFAULT_STEPPING_INVERT_MASK ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT))
+#define DEFAULT_IDLE_LOCK_TIME 25 // ms
 
 void settings_reset() {
   settings.steps_per_mm[X_AXIS] = DEFAULT_X_STEPS_PER_MM;
@@ -66,6 +67,7 @@ void settings_reset() {
   settings.mm_per_arc_segment = DEFAULT_MM_PER_ARC_SEGMENT;
   settings.invert_mask = DEFAULT_STEPPING_INVERT_MASK;
   settings.junction_deviation = DEFAULT_JUNCTION_DEVIATION;
+  settings.idle_lock_time = DEFAULT_IDLE_LOCK_TIME;
 }
 
 void settings_dump() {
@@ -81,6 +83,8 @@ void settings_dump() {
   printPgmString(PSTR(")\r\n$8 = ")); printFloat(settings.acceleration/(60*60)); // Convert from mm/min^2 for human readability
   printPgmString(PSTR(" (acceleration in mm/sec^2)\r\n$9 = ")); printFloat(settings.junction_deviation);
   printPgmString(PSTR(" (cornering junction deviation in mm)"));
+  printPgmString(PSTR("\r\n$10 = ")); printInteger(settings.idle_lock_time);
+  printPgmString(PSTR(" (stepper idle lock time in ms [0 = never unlock])"));
   printPgmString(PSTR("\r\n'$x=value' to set parameter or just '$' to dump current settings\r\n"));
 }
 
@@ -167,6 +171,7 @@ void settings_store_setting(int parameter, double value) {
     case 7: settings.invert_mask = trunc(value); break;
     case 8: settings.acceleration = value*60*60; break; // Convert to mm/min^2 for grbl internal use.
     case 9: settings.junction_deviation = fabs(value); break;
+	case 10: settings.idle_lock_time = value; break;
     default: 
       printPgmString(PSTR("Unknown parameter\r\n"));
       return;

--- a/settings.h
+++ b/settings.h
@@ -43,6 +43,13 @@ typedef struct {
   double mm_per_arc_segment;
   double acceleration;
   double junction_deviation;
+  // This parameter sets the delay time before disabling the steppers after the final block of movement.
+  // A short delay ensures the steppers come to a complete stop and the residual inertial force in the 
+  // CNC axes don't cause the axes to drift off position. This is particularly important when manually 
+  // entering g-code into grbl, i.e. locating part zero or simple manual machining. If the axes drift,
+  // grbl has no way to know this has happened, since stepper motors are open-loop control. Depending
+  // on the machine, this parameter may need to be larger or smaller than the default time.
+  uint16_t idle_lock_time;
 } settings_t;
 extern settings_t settings;
 

--- a/stepper.c
+++ b/stepper.c
@@ -98,11 +98,12 @@ static void st_go_idle()
   TIMSK1 &= ~(1<<OCIE1A); 
   // Force stepper dwell to lock axes for a defined amount of time to ensure the axes come to a complete
   // stop and not drift from residual inertial forces at the end of the last movement.
-  #if STEPPER_IDLE_LOCK_TIME
-    _delay_ms(STEPPER_IDLE_LOCK_TIME);   
-  #endif
-  // Disable steppers by setting stepper disable
-  STEPPERS_DISABLE_PORT |= (1<<STEPPERS_DISABLE_BIT);
+  if(settings.idle_lock_time != 0)
+  {
+    _delay_ms(settings.idle_lock_time);   
+	// Disable steppers by setting stepper disable
+	STEPPERS_DISABLE_PORT |= (1<<STEPPERS_DISABLE_BIT);
+  }
 }
 
 // Initializes the trapezoid generator from the current block. Called whenever a new 


### PR DESCRIPTION
Hello GRBL powers that be :)

I've made the stepper lock delay a user setting instead of a #define constant. In the code it mentions that certain machines may require different settings, and the Shapeoko forum has had a few questions raised about why the steppers don't lock between moves.

AtomSoft also has a patch for this, but mine is a bit more flexible as users can set the delay time to whatever they desire, or turn unlocking off.
