### PR TITLE
Fix sim makefile so it works on mac

### DIFF
--- a/sim/.gitignore
+++ b/sim/.gitignore
@@ -1,0 +1,1 @@
+grbl_sim.exe

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -15,13 +15,10 @@
 #  You should have received a copy of the GNU General Public License
 #  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
-OBJECTS    = main.o simulator.o runtime.o ../protocol.o ../planner.o ../settings.o ../print.o ../nuts_bolts.o eeprom.o serial.o avr\pgmspace.o avr\interrupt.o util\delay.o util\floatunsisf.o ../stepper.o ../gcode.o ../spindle_control.o ../motion_control.o ../limits.o ../report.o ../coolant_control.o
-
-             
+OBJECTS    = main.o simulator.o runtime.o ../protocol.o ../planner.o ../settings.o ../print.o ../nuts_bolts.o eeprom.o serial.o avr/pgmspace.o avr/interrupt.o util/delay.o util/floatunsisf.o ../stepper.o ../gcode.o ../spindle_control.o ../motion_control.o ../limits.o ../report.o ../coolant_control.o
 CLOCK      = 16000000
-EXE_NAME= grbl_sim.exe
-COMPILER= C:\MinGW\bin\gcc.exe
-COMPILE = $(COMPILER) -Wall -Os -DF_CPU=$(CLOCK) -include config.h -I.
+EXE_NAME   = grbl_sim.exe
+COMPILE    = $(CC) -Wall -Os -DF_CPU=$(CLOCK) -include config.h -I.
 
 # symbolic targets:
 all:	main
@@ -33,15 +30,15 @@ clean:
 
 # file targets:
 main: $(OBJECTS)
-	$(COMPILE) -o $(EXE_NAME) $(OBJECTS) -lm -Wl,--gc-sections
+	$(COMPILE) -o $(EXE_NAME) $(OBJECTS) -lm
 
 %.o: %.c
 	$(COMPILE) -c $< -o $@
-	
+
 ../protocol.o: ../protocol.c
-	$(COMPILE) -include rename_execute_runtime.h -c $< -o $@ 
-	
+	$(COMPILE) -include rename_execute_runtime.h -c $< -o $@
+
 ../planner.o: ../planner.c
-	$(COMPILE) -include planner_inject_accessors.c -c $< -o $@ 
-	
-	
+	$(COMPILE) -include planner_inject_accessors.c -c $< -o $@
+
+


### PR DESCRIPTION
These changes include a path separator fix and the removal of --gc-sections which causes ld failures, and is not needed on a pc.

This patch also changes how a compiler is selected.  The makefile will now select the system compiler , which should work fine
under mingw and linux.
