### PR TITLE
use EXEEXT for simulator extension

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -17,7 +17,7 @@
 
 OBJECTS    = main.o simulator.o runtime.o ../protocol.o ../planner.o ../settings.o ../print.o ../nuts_bolts.o eeprom.o serial.o avr/pgmspace.o avr/interrupt.o util/delay.o util/floatunsisf.o ../stepper.o ../gcode.o ../spindle_control.o ../motion_control.o ../limits.o ../report.o ../coolant_control.o
 CLOCK      = 16000000
-EXE_NAME   = grbl_sim.exe
+EXE_NAME   = grbl_sim$(EXEEXT)
 COMPILE    = $(CC) -Wall -Os -DF_CPU=$(CLOCK) -include config.h -I.
 
 # symbolic targets:


### PR DESCRIPTION
@jgeisler0303 can you take a peek at this? On *nix `EXEEXT` is '', on windows it should be `.exe`
