### PR TITLE
Add support for active-high limit switches

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -52,6 +52,7 @@
   #define DEFAULT_STEPPER_IDLE_LOCK_TIME 25 // msec (0-255)
   #define DEFAULT_DECIMAL_PLACES 3
   #define DEFAULT_N_ARC_CORRECTION 25
+  #define DEFAULT_LIMIT_POLARITY 0 // false (active low).
 #endif
 
 #ifdef DEFAULTS_SHERLINE_5400

--- a/report.c
+++ b/report.c
@@ -171,7 +171,8 @@ void report_grbl_settings() {
   printPgmString(PSTR(" (homing feed, mm/min)\r\n$20=")); printFloat(settings.homing_seek_rate);
   printPgmString(PSTR(" (homing seek, mm/min)\r\n$21=")); printInteger(settings.homing_debounce_delay);
   printPgmString(PSTR(" (homing debounce, msec)\r\n$22=")); printFloat(settings.homing_pulloff);
-  printPgmString(PSTR(" (homing pull-off, mm)\r\n")); 
+  printPgmString(PSTR(" (homing pull-off, mm)\r\n$23=")); printInteger(bit_istrue(settings.flags,BITFLAG_LIMIT_POLARITY));
+  printPgmString(PSTR(" (limit switches active high, bool)\r\n")); 
 }
 
 

--- a/settings.c
+++ b/settings.c
@@ -87,6 +87,7 @@ void settings_reset(bool reset_all) {
   if (DEFAULT_INVERT_ST_ENABLE) { settings.flags |= BITFLAG_INVERT_ST_ENABLE; }
   if (DEFAULT_HARD_LIMIT_ENABLE) { settings.flags |= BITFLAG_HARD_LIMIT_ENABLE; }
   if (DEFAULT_HOMING_ENABLE) { settings.flags |= BITFLAG_HOMING_ENABLE; }
+  if (DEFAULT_LIMIT_POLARITY) { settings.flags |= BITFLAG_LIMIT_POLARITY; }
   settings.homing_dir_mask = DEFAULT_HOMING_DIR_MASK;
   settings.homing_feed_rate = DEFAULT_HOMING_FEEDRATE;
   settings.homing_seek_rate = DEFAULT_HOMING_RAPID_FEEDRATE;
@@ -195,6 +196,11 @@ uint8_t settings_store_global_setting(int parameter, float value) {
     case 20: settings.homing_seek_rate = value; break;
     case 21: settings.homing_debounce_delay = round(value); break;
     case 22: settings.homing_pulloff = value; break;
+    case 23:
+      if (value) { settings.flags |= BITFLAG_LIMIT_POLARITY; }
+      else { settings.flags &= ~BITFLAG_LIMIT_POLARITY; }
+      limits_init(); // Re-init to immediately change. NOTE: Nice to have but could be problematic later.
+      break;
     default: 
       return(STATUS_INVALID_STATEMENT);
   }

--- a/settings.h
+++ b/settings.h
@@ -37,6 +37,7 @@
 #define BITFLAG_INVERT_ST_ENABLE   bit(2)
 #define BITFLAG_HARD_LIMIT_ENABLE  bit(3)
 #define BITFLAG_HOMING_ENABLE      bit(4)
+#define BITFLAG_LIMIT_POLARITY     bit(5)
 
 // Define EEPROM memory address location values for Grbl settings and parameters
 // NOTE: The Atmega328p has 1KB EEPROM. The upper half is reserved for parameters and


### PR DESCRIPTION
A friend of mine wanted to use some optical interrupter modules that signaled high when their beam was broken. A minor software change was required to accomplish this, and this patch surfaces that change as a setting. Configuring the new variable $23 as "true" will cause grbl to enable active-high limit switch support (internal pullups disabled, homing cycle inverts invert_pin), while "false" (the default) will leave grbl with its original behavior for supporting active-low switches.
