### PR TITLE
Add support for active-high limit switches

### DIFF
--- a/config.h
+++ b/config.h
@@ -171,6 +171,12 @@
 // successful values for certain setups have ranged from 10 to 20us.
 // #define STEP_PULSE_DELAY 10 // Step pulse delay in microseconds. Default disabled.
 
+// Uncomment the following define if you are using hardware that drives high when your limits
+// are reached. You will need to ensure that you have appropriate pull-down resistors on the
+// limit switch input pins, or that your hardware drives the pins low when they are open (non-
+// triggered).
+// #define LIMIT_SWITCHES_ACTIVE_HIGH
+
 // ---------------------------------------------------------------------------------------
 
 // TODO: Install compile-time option to send numeric status codes rather than strings.


### PR DESCRIPTION
This patch allows for building a version of grbl which expects the limit switches to be active high, instead of active low. The functionality is enabled at compile time by defining the macro LIMIT_SWITCHES_ACTIVE_HIGH, which has been documented in config.h. Active-low limit switches are still the default.
