### PR TITLE
changing version of precompiled hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Grbl includes full acceleration management with look ahead. That means the contr
 
 ##Downloads (Right-Click and Save-Link-As):
 _**Master Branch:**_
-* [Grbl v0.8c Atmega328p 16mhz 9600baud](http://bit.ly/SSdCJE) (Last updated: 2013-12-07)
+* [Grbl v0.8d Atmega328p 16mhz 9600baud](http://bit.ly/SSdCJE) (Last updated: 2013-12-07)
   - 2013-12-07: G18 and serial volatile fixes.
   - 2013-04-05: Line buffer increased and overflow feedback added.
 


### PR DESCRIPTION
The old version was 0.8c. New build (2013-12-07) should increment to denote change.

I dont' have access to the downloadable .hex, but it's filename will need to be changed as well.
