### PR TITLE
Line number reporting as compile-time option.

### DIFF
--- a/config.h
+++ b/config.h
@@ -28,6 +28,10 @@
 #ifndef config_h
 #define config_h
 
+// Allows GRBL to tranck and report gcode line numbers.  Enabling this means that the planning buffer
+// goes from 18 or 16 to make room for the additional line number data in the plan_block_t struct
+#define USE_LINE_NUMBERS
+
 // Default settings. Used when resetting EEPROM. Change to desired name in defaults.h
 #define DEFAULTS_SHERLINE_5400
 

--- a/gcode.c
+++ b/gcode.c
@@ -101,6 +101,7 @@ uint8_t gc_execute_line(char *line)
   float target[N_AXIS];
   clear_vector(target); // XYZ(ABC) axes parameters.
 
+  uint32_t line_number = 0;
   gc.arc_radius = 0;
   clear_vector(gc.arc_offset); // IJK Arc offsets are incremental. Value of zero indicates no change.
 
@@ -215,7 +216,7 @@ uint8_t gc_execute_line(char *line)
   char_counter = 0;
   while(next_statement(&letter, &value, line, &char_counter)) {
     switch(letter) {
-      case 'G': case 'M': case 'N': break; // Ignore command statements and line numbers
+      case 'G': case 'M': break; // Ignore command statements and line numbers
       case 'F': 
         if (value <= 0) { FAIL(STATUS_INVALID_STATEMENT); } // Must be greater than zero
         if (gc.inverse_feed_rate_mode) {
@@ -226,6 +227,7 @@ uint8_t gc_execute_line(char *line)
         break;
       case 'I': case 'J': case 'K': gc.arc_offset[letter-'I'] = to_millimeters(value); break;
       case 'L': l = trunc(value); break;
+      case 'N': line_number = trunc(value); break;
       case 'P': p = value; break;                    
       case 'R': gc.arc_radius = to_millimeters(value); break;
       case 'S': 
@@ -329,7 +331,7 @@ uint8_t gc_execute_line(char *line)
             target[idx] = gc.position[idx];
           }
         }
-        mc_line(target, -1.0, false);
+        mc_line(target, -1.0, false, line_number);
       }
       // Retreive G28/30 go-home position data (in machine coordinates) from EEPROM
       float coord_data[N_AXIS];
@@ -338,7 +340,7 @@ uint8_t gc_execute_line(char *line)
       } else {
         if (!settings_read_coord_data(SETTING_INDEX_G30,coord_data)) { return(STATUS_SETTING_READ_FAIL); }
       }
-      mc_line(coord_data, -1.0, false); 
+      mc_line(coord_data, -1.0, false, line_number); 
       memcpy(gc.position, coord_data, sizeof(coord_data)); // gc.position[] = coord_data[];
       axis_words = 0; // Axis words used. Lock out from motion modes by clearing flags.
       break;
@@ -409,7 +411,7 @@ uint8_t gc_execute_line(char *line)
         break;
       case MOTION_MODE_SEEK:
         if (!axis_words) { FAIL(STATUS_INVALID_STATEMENT);} 
-        else { mc_line(target, -1.0, false); }
+        else { mc_line(target, -1.0, false, line_number); }
         break;
       case MOTION_MODE_LINEAR:
         // TODO: Inverse time requires F-word with each statement. Need to do a check. Also need
@@ -417,7 +419,7 @@ uint8_t gc_execute_line(char *line)
         // and after an inverse time move and then check for non-zero feed rate each time. This
         // should be efficient and effective.
         if (!axis_words) { FAIL(STATUS_INVALID_STATEMENT);} 
-        else { mc_line(target, (gc.inverse_feed_rate_mode) ? inverse_feed_rate : gc.feed_rate, gc.inverse_feed_rate_mode); }
+        else { mc_line(target, (gc.inverse_feed_rate_mode) ? inverse_feed_rate : gc.feed_rate, gc.inverse_feed_rate_mode, line_number); }
         break;
       case MOTION_MODE_CW_ARC: case MOTION_MODE_CCW_ARC:
         // Check if at least one of the axes of the selected plane has been specified. If in center 
@@ -441,7 +443,7 @@ uint8_t gc_execute_line(char *line)
           // Trace the arc
           mc_arc(gc.position, target, gc.arc_offset, gc.plane_axis_0, gc.plane_axis_1, gc.plane_axis_2,
             (gc.inverse_feed_rate_mode) ? inverse_feed_rate : gc.feed_rate, gc.inverse_feed_rate_mode,
-            gc.arc_radius, isclockwise);
+            gc.arc_radius, isclockwise, line_number);
         }            
         break;
     }

--- a/motion_control.h
+++ b/motion_control.h
@@ -22,18 +22,19 @@
 #ifndef motion_control_h
 #define motion_control_h
 
+#define HOMING_CYCLE_LINE_NUMBER 1000000000
 
 // Execute linear motion in absolute millimeter coordinates. Feed rate given in millimeters/second
 // unless invert_feed_rate is true. Then the feed_rate means that the motion should be completed in
 // (1 minute)/feed_rate time.
-void mc_line(float *target, float feed_rate, uint8_t invert_feed_rate);
+void mc_line(float *target, float feed_rate, uint8_t invert_feed_rate, uint32_t line_number);
 
 // Execute an arc in offset mode format. position == current xyz, target == target xyz, 
 // offset == offset from current xyz, axis_XXX defines circle plane in tool space, axis_linear is
 // the direction of helical travel, radius == circle radius, isclockwise boolean. Used
 // for vector transformation direction.
 void mc_arc(float *position, float *target, float *offset, uint8_t axis_0, uint8_t axis_1,
-  uint8_t axis_linear, float feed_rate, uint8_t invert_feed_rate, float radius, uint8_t isclockwise);
+  uint8_t axis_linear, float feed_rate, uint8_t invert_feed_rate, float radius, uint8_t isclockwise, uint32_t line_number);
   
 // Dwell for a specific number of seconds
 void mc_dwell(float seconds);

--- a/planner.c
+++ b/planner.c
@@ -259,7 +259,7 @@ uint8_t plan_check_full_buffer()
    is used in three ways: as a normal feed rate if invert_feed_rate is false, as inverse time if
    invert_feed_rate is true, or as seek/rapids rate if the feed_rate value is negative (and
    invert_feed_rate always false). */
-void plan_buffer_line(float *target, float feed_rate, uint8_t invert_feed_rate) 
+void plan_buffer_line(float *target, float feed_rate, uint8_t invert_feed_rate, uint32_t line_number) 
 {
   // Prepare and initialize new block
   plan_block_t *block = &block_buffer[block_buffer_head];
@@ -267,7 +267,9 @@ void plan_buffer_line(float *target, float feed_rate, uint8_t invert_feed_rate)
   block->millimeters = 0;
   block->direction_bits = 0;
   block->acceleration = SOME_LARGE_VALUE; // Scaled down to maximum acceleration later
-
+#ifdef USE_LINE_NUMBERS
+  block->line_number = line_number;
+#endif
   // Compute and store initial move distance data.
   // TODO: After this for-loop, we don't touch the stepper algorithm data. Might be a good idea
   // to try to keep these types of things completely separate from the planner for portability.

--- a/planner.h
+++ b/planner.h
@@ -26,7 +26,11 @@
 
 // The number of linear motions that can be in the plan at any give time
 #ifndef BLOCK_BUFFER_SIZE
-  #define BLOCK_BUFFER_SIZE 18
+  #ifdef USE_LINE_NUMBERS
+    #define BLOCK_BUFFER_SIZE 16
+  #else
+    #define BLOCK_BUFFER_SIZE 18
+  #endif
 #endif
 
 // This struct stores a linear movement of a g-code block motion with its critical "nominal" values
@@ -47,6 +51,9 @@ typedef struct {
   float acceleration;            // Axis-limit adjusted line acceleration in (mm/min^2)
   float millimeters;             // The remaining distance for this block to be executed in (mm)
   // uint8_t max_override;       // Maximum override value based on axis speed limits
+#ifdef USE_LINE_NUMBERS
+  uint32_t line_number;
+#endif
 } plan_block_t;
 
       
@@ -56,7 +63,7 @@ void plan_reset();
 // Add a new linear movement to the buffer. target[N_AXIS] is the signed, absolute target position 
 // in millimeters. Feed rate specifies the speed of the motion. If feed rate is inverted, the feed
 // rate is taken to mean "frequency" and would complete the operation in 1/feed_rate minutes.
-void plan_buffer_line(float *target, float feed_rate, uint8_t invert_feed_rate);
+void plan_buffer_line(float *target, float feed_rate, uint8_t invert_feed_rate, uint32_t line_number);
 
 // Called when the current block is no longer needed. Discards the block and makes the memory
 // availible for new blocks.

--- a/report.c
+++ b/report.c
@@ -32,6 +32,7 @@
 #include "settings.h"
 #include "gcode.h"
 #include "coolant_control.h"
+#include "planner.h"
 #include "spindle_control.h"
 
 
@@ -261,9 +262,9 @@ void report_gcode_modes()
   }
 
   switch (gc.spindle_direction) {
-    case SPINDLE_ENABLE_CW  : printPgmString(PSTR(" M3")); break;
-    case SPINDLE_ENABLE_CCW  : printPgmString(PSTR(" M4")); break;
-    case SPINDLE_DISABLE : printPgmString(PSTR(" M5")); break;
+    case 1 : printPgmString(PSTR(" M3")); break;
+    case -1 : printPgmString(PSTR(" M4")); break;
+    case 0 : printPgmString(PSTR(" M5")); break;
   }
   
   switch (gc.coolant_mode) {
@@ -349,6 +350,18 @@ void report_realtime_status()
     printFloat(print_position[i]);
     if (i < (N_AXIS-1)) { printPgmString(PSTR(",")); }
   }
+    
+#ifdef USE_LINE_NUMBERS
+  // Report current line number
+  printPgmString(PSTR(","));
+  printPgmString(PSTR("Ln:")); 
+  uint32_t ln=0;
+  plan_block_t * pb = plan_get_current_block();
+  if(pb != NULL) {
+    ln = pb->line_number;
+  } 
+  printInteger(ln);
+#endif
     
   printPgmString(PSTR(">\r\n"));
 }


### PR DESCRIPTION
- Initial installation of line number status reporting to indicate the line number block currently being executed. Enabled by a compile-time option, but requires the planner buffer to be reduced from 18 to 16 blocks, since these require int32 variables to be stored.
