### PR TITLE
Probing command gets stuck in hold if several g38.2 are submitted

### DIFF
--- a/motion_control.c
+++ b/motion_control.c
@@ -279,6 +279,7 @@ void mc_probe_cycle(float *target, float feed_rate, uint8_t invert_feed_rate, in
 void mc_probe_cycle(float *target, float feed_rate, uint8_t invert_feed_rate)
 #endif
 {
+  if (sys.state != STATE_CYCLE) protocol_auto_cycle_start();
   protocol_buffer_synchronize(); // Finish all queued commands
   if (sys.abort) { return; } // Return if system reset has been issued.
 


### PR DESCRIPTION
Ex.
G0 X0 Y0 Z0
G38.2 Z-10 F100
G10 L20 P0 Z0
G0 Z2
G38.2 Z-1 F50
G10 L20 P0 Z0
G0 Z2
G0 X0 Y0
G38.2 Z-1 F100
G0 Z2
