### PR TITLE
Change the interrupt handling to better support chips with more then 1 UART

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -91,7 +91,7 @@ void serial_write(uint8_t data) {
 }
 
 // Data Register Empty Interrupt handler
-#ifdef __AVR_ATmega644P__
+#if defined(USART0_UDRE_vect)
 ISR(USART0_UDRE_vect)
 #else
 ISR(USART_UDRE_vect)
@@ -144,7 +144,7 @@ uint8_t serial_read()
   }
 }
 
-#ifdef __AVR_ATmega644P__
+#if defined(USART0_RX_vect)
 ISR(USART0_RX_vect)
 #else
 ISR(USART_RX_vect)


### PR DESCRIPTION
I've made a small change to how the serial interrupt vectors are defined. This because I tried to compile the code for an ATMega2560, and the interrupts did not get properly defined then.

The below change works because interrupts are defined as "_VECTOR(??)" in avr/io.h
