### PR TITLE
Alarm if limits engaged on homing start.

### DIFF
--- a/motion_control.c
+++ b/motion_control.c
@@ -242,7 +242,7 @@ void mc_homing_cycle()
 {
   uint8_t limits_on;
   if (bit_istrue(settings.flags,BITFLAG_INVERT_LIMIT_PINS)) {
-    limits_on = (LIMIT_PIN ^ LIMIT_MASK);
+    limits_on = ((~LIMIT_PIN) & LIMIT_MASK);
   } else {
     limits_on =  (LIMIT_PIN & LIMIT_MASK);
   }


### PR DESCRIPTION
Potential fix for #482. Uses same alarm as soft limits.
Now in edge, and with no false alarms.
