### PR TITLE
Digital output control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
 DEVICE     ?= atmega328p
 CLOCK      = 16000000
 PROGRAMMER ?= -c avrisp2 -P usb
-OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \
+OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o dio_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o nuts_bolts.o limits.o \
              print.o probe.o report.o system.o
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m

--- a/config.h
+++ b/config.h
@@ -156,6 +156,10 @@
 // The hardware PWM output on pin D11 is required for variable spindle output voltages.
 // #define VARIABLE_SPINDLE // Default disabled. Uncomment to enable.
 
+// Enables DIO Control which provides M64 and M65 commands. Currently only supported on ATMEGA2560
+// unless you exchange some pins on the Arduino Uno for this command
+// #define DIO_CONTROL // Default disabled. Uncomment to enable.
+
 // Use by the variable spindle output only. These parameters set the maximum and minimum spindle speed
 // "S" g-code values to correspond to the maximum and minimum pin voltages. There are 256 discrete and 
 // equally divided voltage bins between the maximum and minimum spindle speeds. So for a 5V pin, 1000

--- a/cpu_map.h
+++ b/cpu_map.h
@@ -138,7 +138,6 @@
     #define SPINDLE_PWM_PORT  SPINDLE_ENABLE_PORT
     #define SPINDLE_PWM_BIT	  SPINDLE_ENABLE_BIT // Shared with SPINDLE_ENABLE.
   #endif // End of VARIABLE_SPINDLE
-
 #endif
 
 
@@ -362,6 +361,15 @@
     #define SPINDLE_PWM_PORT    PORTH
     #define SPINDLE_PWM_BIT		6 // MEGA2560 Digital Pin 9
   #endif // End of VARIABLE_SPINDLE
+
+  #ifdef DIO_CONTROL
+    #define DIGITAL_IO_DDR DDRC
+    #define DIGITAL_IO_PORT PORTC
+    #define DIGITAL_IO_BIT0 0 // MEGA2560 Digital Pin 37
+    #define DIGITAL_IO_BIT1 1 // MEGA2560 Digital Pin 36
+    #define DIGITAL_IO_BIT2 2 // MEGA2560 Digital Pin 35
+    #define DIGITAL_IO_BIT3 3 // MEGA2560 Digital Pin 34
+  #endif
 
 #endif
 

--- a/dio_control.c
+++ b/dio_control.c
@@ -1,0 +1,77 @@
+/*
+  dio_control.c - digital i/o control methods
+  Part of Grbl v0.9
+
+  Copyright (c) 2012-2014 Sungeun K. Jeon
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/  
+
+#include "system.h"
+#include "dio_control.h"
+#include "protocol.h"
+#include "gcode.h"
+
+
+void dio_init()
+{
+  #ifdef DIO_CONTROL
+    DIGITAL_IO_DDR |= (1 << DIGITAL_IO_BIT0);
+    DIGITAL_IO_DDR |= (1 << DIGITAL_IO_BIT1);
+    DIGITAL_IO_DDR |= (1 << DIGITAL_IO_BIT2);
+    DIGITAL_IO_DDR |= (1 << DIGITAL_IO_BIT3);
+    dio_stop();
+  #endif
+}
+
+void dio_stop()
+{
+  #ifdef DIO_CONTROL
+    DIGITAL_IO_PORT &= ~(1 << DIGITAL_IO_BIT0);
+    DIGITAL_IO_PORT &= ~(1 << DIGITAL_IO_BIT1);
+    DIGITAL_IO_PORT &= ~(1 << DIGITAL_IO_BIT2);
+    DIGITAL_IO_PORT &= ~(1 << DIGITAL_IO_BIT3);
+  #endif
+}
+
+void dio_immediate_run(uint8_t mode, uint8_t pin)
+{
+  #ifdef DIO_CONTROL
+    if (sys.state == STATE_CHECK_MODE) { return; }
+
+    protocol_auto_cycle_start();   //temp fix for M8 lockup
+    protocol_buffer_synchronize(); // Ensure digital i/o turns on when specified in program.
+
+    uint8_t bit;
+    switch (pin) {
+      case 0:
+        bit = DIGITAL_IO_BIT0; break;
+      case 1:
+        bit = DIGITAL_IO_BIT1; break;
+      case 2:
+        bit = DIGITAL_IO_BIT2; break;
+      case 3:
+      default:
+        bit = DIGITAL_IO_BIT3; break;
+    }
+
+    if (mode == DIGITAL_OUTPUT_IMMEDIATE_ENABLE) {
+      DIGITAL_IO_PORT |= (1 << bit);
+    } else if (mode == DIGITAL_OUTPUT_IMMEDIATE_DISABLE) {
+      DIGITAL_IO_PORT &= ~(1 << bit);
+    } else {
+      dio_stop();
+    }
+  #endif
+}

--- a/dio_control.h
+++ b/dio_control.h
@@ -1,0 +1,29 @@
+/*
+  digital_control.h - Digital I/O Control methods
+  Part of Grbl v0.9
+
+  Copyright (c) 2012-2014 Sungeun K. Jeon
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef digital_control_h
+#define digital_control_h 
+
+
+void dio_init();
+void dio_stop();
+void dio_immediate_run(uint8_t mode, uint8_t pin);
+
+#endif

--- a/gcode.h
+++ b/gcode.h
@@ -46,10 +46,11 @@
 #define MODAL_GROUP_M4 8  // [M0,M1,M2,M30] Stopping
 #define MODAL_GROUP_M7 9  // [M3,M4,M5] Spindle turning
 #define MODAL_GROUP_M8 10 // [M7,M8,M9] Coolant control
+#define MODAL_GROUP_M9 11 // [M64,M65] Immediate Digital Output Control
 
-#define OTHER_INPUT_F 11
-#define OTHER_INPUT_S 12
-#define OTHER_INPUT_T 13
+#define OTHER_INPUT_F 12
+#define OTHER_INPUT_S 13
+#define OTHER_INPUT_T 14
 
 // Define command actions for within execution-type modal groups (motion, stopping, non-modal). Used
 // internally by the parser to know which command to execute.
@@ -110,6 +111,10 @@
 #define TOOL_LENGTH_OFFSET_CANCEL 0 // G49 (Default: Must be zero)
 #define TOOL_LENGTH_OFFSET_ENABLE_DYNAMIC 1 // G43.1
 
+// Modal Group M9: Immediate Digital Output Control
+#define DIGITAL_OUTPUT_IMMEDIATE_DISABLE 0
+#define DIGITAL_OUTPUT_IMMEDIATE_ENABLE 1
+
 // Modal Group G12: Active work coordinate system
 // N/A: Stores coordinate system value (54-59) to change to.
 
@@ -142,6 +147,7 @@ typedef struct {
   uint8_t program_flow;  // {M0,M1,M2,M30}
   uint8_t coolant;       // {M7,M8,M9}
   uint8_t spindle;       // {M3,M4,M5}
+  uint8_t dio_immediate; // {M64,M65}
 } gc_modal_t;  
 
 typedef struct {

--- a/main.c
+++ b/main.c
@@ -78,6 +78,7 @@ int main(void)
     gc_init(); // Set g-code parser to default state
     spindle_init();
     coolant_init();
+    dio_init();
     limits_init(); 
     probe_init();
     plan_reset(); // Clear block buffer and planner variables

--- a/motion_control.c
+++ b/motion_control.c
@@ -34,6 +34,7 @@
 #include "motion_control.h"
 #include "spindle_control.h"
 #include "coolant_control.h"
+#include "dio_control.h"
 #include "limits.h"
 #include "probe.h"
 #include "report.h"
@@ -360,9 +361,10 @@ void mc_reset()
   if (bit_isfalse(sys.execute, EXEC_RESET)) {
     bit_true_atomic(sys.execute, EXEC_RESET);
 
-    // Kill spindle and coolant.   
+    // Kill spindle and coolant and any digital i/o control.
     spindle_stop();
     coolant_stop();
+    dio_stop();
 
     // Kill steppers only if in any motion state, i.e. cycle, feed hold, homing, or jogging
     // NOTE: If steppers are kept enabled via the step idle delay setting, this also keeps

--- a/report.c
+++ b/report.c
@@ -32,6 +32,7 @@
 #include "settings.h"
 #include "gcode.h"
 #include "coolant_control.h"
+#include "dio_control.h"
 #include "planner.h"
 #include "spindle_control.h"
 #include "stepper.h"
@@ -48,10 +49,9 @@
 // TODO: Install silent mode to return only numeric values, primarily for GUIs.
 void report_status_message(uint8_t status_code) 
 {
-  if (status_code == 0) { // STATUS_OK
-    printPgmString(PSTR("ok\r\n"));
-  } else {
-    printPgmString(PSTR("error: "));
+
+  if (status_code != 0) { // STATUS_OK
+    printPgmString(PSTR(": error \""));
     switch(status_code) {          
       case STATUS_EXPECTED_COMMAND_LETTER:
       printPgmString(PSTR("Expected command letter")); break;
@@ -77,6 +77,8 @@ void report_status_message(uint8_t status_code)
       printPgmString(PSTR("Line overflow")); break; 
       
       // Common g-code parser errors.
+      case STATUS_GCODE_UNUSED_WORDS:
+      printPgmString(PSTR("Unused Words")); break;
       case STATUS_GCODE_MODAL_GROUP_VIOLATION:
       printPgmString(PSTR("Modal group violation")); break;
       case STATUS_GCODE_UNSUPPORTED_COMMAND:
@@ -85,11 +87,12 @@ void report_status_message(uint8_t status_code)
       printPgmString(PSTR("Undefined feed rate")); break;
       default:
         // Remaining g-code parser errors with error codes
-        printPgmString(PSTR("Invalid gcode ID:"));
+        printPgmString(PSTR("Invalid gcode ID: "));
         print_uint8_base10(status_code); // Print error code for user reference
     }
-    printPgmString(PSTR("\r\n"));
+    printPgmString(PSTR("\""));
   }
+  printPgmString(PSTR("\r\n"));
 }
 
 // Prints alarm messages.


### PR DESCRIPTION
This adds support for GCode commands M64/M65 which can be useful when adding some customized functionality to a CNC. It currently is only supported on the ATMega 2560 unless you move some pins around on the Arduino Uno in cpu_map.h

This also improves the serial monitor so when a command is typed, it is echoed back to the console followed by an error message if there was any. This allows you to see the history of commands that lead up to a particular point and doesn't leave you guessing as to what was entered if there was an error

Thank you for all the amazing work on grbl!
