### PR TITLE
No longer disable internal pullups when inverting the limit pins

### DIFF
--- a/config.h
+++ b/config.h
@@ -255,6 +255,26 @@
 // work well and are cheap to find) and wire in a low-pass circuit into each limit pin.
 // #define ENABLE_SOFTWARE_DEBOUNCE // Default disabled. Uncomment to enable.
 
+
+// Enable the internal pullup resistors on the limit pin inputs. These
+// allow wiring up limit switches directly to ground and these inputs,
+// without the pin value floating when the switch is opened. These
+// pullups can be used with both normally-open and normally-closed limit
+// switches (but when using normally-closed switches, remember to enable
+// the invert limit switches configuration at runtime).
+// These internal pullups are fairly big (20kΩ - 50kΩ for Arduino Uno),
+// which can cause problems in some environments. To solve this, an
+// extra (smaller) external pullup can be added. There is no need to
+// disable the internal pullups then, both will contribute to the
+// pulling up of the signal). Disabling the internal pullups should only
+// be needed in non-standard configurations that do not any pullup or
+// require a pulldown register.
+// In grbl 0.9 and before, these internal pullups were disabled
+// automatically when the invert limit switches runtime configuration
+// was enabled, but there wasn't really any point to that, so these two
+// got separated.
+#define ENABLE_LIMIT_PULLUPS
+
 // ---------------------------------------------------------------------------------------
 
 // TODO: Install compile-time option to send numeric status codes rather than strings.

--- a/limits.c
+++ b/limits.c
@@ -41,11 +41,11 @@ void limits_init()
 {
   LIMIT_DDR &= ~(LIMIT_MASK); // Set as input pins
 
-  if (bit_istrue(settings.flags,BITFLAG_INVERT_LIMIT_PINS)) {
-    LIMIT_PORT &= ~(LIMIT_MASK); // Normal low operation. Requires external pull-down.
-  } else {
-    LIMIT_PORT |= (LIMIT_MASK);  // Enable internal pull-up resistors. Normal high operation.
-  }
+#ifdef ENABLE_LIMIT_PULLUPS
+    LIMIT_PORT |= (LIMIT_MASK);
+#else
+    LIMIT_PORT &= ~(LIMIT_MASK);
+#endif
 
   if (bit_istrue(settings.flags,BITFLAG_HARD_LIMIT_ENABLE)) {
     LIMIT_PCMSK |= LIMIT_MASK; // Enable specific pins of the Pin Change Interrupt


### PR DESCRIPTION
Before, these two were coupled, meaning you could not invert the limit
pins without disabling the pullups and vice versa. Now, these two are
separated. Inverting the pins is still a runtime setting as before,
disabling the internal pullups is now a compiletime setting (which
defaults to enabled).

Separating these two makes it easier to support normally-closed
switches, which can be wired to GND normally when the pins are inverted,
but pullups remain enabled.

Closes: #542