### PR TITLE
Fix EXEC_ALARM_* flags: soft limit would lead to hard limit error.

### DIFF
--- a/grbl/system.h
+++ b/grbl/system.h
@@ -41,10 +41,10 @@
 // this halts Grbl into an infinite loop until the user aknowledges the problem and issues a soft-
 // reset command. For example, a hard limit event needs this type of halt and aknowledgement.
 #define EXEC_CRITICAL_EVENT     bit(0) // bitmask 00000001 (SPECIAL FLAG. See NOTE:)
-#define EXEC_ALARM_HARD_LIMIT   bit(0) // bitmask 00000010
-#define EXEC_ALARM_SOFT_LIMIT   bit(1) // bitmask 00000100
-#define EXEC_ALARM_ABORT_CYCLE  bit(2) // bitmask 00001000
-#define EXEC_ALARM_PROBE_FAIL   bit(3) // bitmask 00010000
+#define EXEC_ALARM_HARD_LIMIT   bit(1) // bitmask 00000010
+#define EXEC_ALARM_SOFT_LIMIT   bit(2) // bitmask 00000100
+#define EXEC_ALARM_ABORT_CYCLE  bit(3) // bitmask 00001000
+#define EXEC_ALARM_PROBE_FAIL   bit(4) // bitmask 00010000
 
 // Define system state bit map. The state variable primarily tracks the individual functions
 // of Grbl to manage each without overlapping. It is also used as a messaging flag for


### PR DESCRIPTION
First of all: many thanks for such a wonderful piece of software!
I've been running LinuxCNC for quite some time, but the old laptop is starting to get grumpy, and Grbl seems to be the answer to the lack of a parallel port on my new laptop ;)

While switching to Grbl, I ran into an issue where I accidentally entered a move that hit a soft limit, but instead was told the move resulted in a hard limit. Caused by EXEC_ALARM_SOFT_LIMIT also setting EXEC_CRITICAL_EVENT, which had the same value as EXEC_ALARM_HARD_LIMIT.

Not sure whether EXEC_CRITICAL_EVENT should be a flag on its own, as it could probably be a mask of the other events that would need critical handling, but this PR fixes the issue with minimal impact.