### PR TITLE
Fix generating header dependencies, merge with 'normal' compile, force r...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ OBJECTS = $(addprefix $(BUILDDIR)/,$(notdir $(SOURCE:.c=.o)))
 all:	grbl.hex
 
 $(BUILDDIR)/%.o: $(SOURCEDIR)/%.c
-	$(COMPILE) -c $< -o $@
-	@$(COMPILE) -MM  $< > $(BUILDDIR)/$*.d
+	$(COMPILE) -MMD -MP -c $< -o $@
 
 .S.o:
 	$(COMPILE) -x assembler-with-cpp -c $< -o $(BUILDDIR)/$@


### PR DESCRIPTION
Sources are no longer automatically rebuilt since output has been moved to build/.

This fixes the generated .d files, generates them as part of the 'normal' compile (-MMD, thus eliminating an extra call to the compiler), and makes sure that files are recompiled when a file is removed (-MP).