### PR TITLE
Fix function signature of print_uint32_base10(), necessary for compiling simulator.

### DIFF
--- a/grbl/print.c
+++ b/grbl/print.c
@@ -100,7 +100,7 @@ void print_uint8_base10(uint8_t n)
 }
 
 
-void print_uint32_base10(unsigned long n)
+void print_uint32_base10(uint32_t n)
 { 
   if (n == 0) {
     serial_write('0');


### PR DESCRIPTION
Ran into a small issue while trying to compile grbl-sim, where print.h and print.c don't agree on their argument type.