### PR TITLE
Split each CPU map into its own file.

### DIFF
--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -18,8 +18,9 @@
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* The cpu_map.h file serves as a central pin mapping settings file for different processor
-   types, i.e. AVR 328p or AVR Mega 2560. Grbl officially supports the Arduino Uno, but the 
+/* The cpu_map.h file serves as a central pin mapping selection file for different processor
+   types, i.e. AVR 328p or AVR Mega 2560. Each processor has its own pin mapping file.
+   (i.e. cpu_map_atmega328p.h)  Grbl officially supports the Arduino Uno, but the 
    other supplied pin mappings are supplied by users, so your results may vary. */
 
 // NOTE: This is still a work in progress. We are still centralizing the configurations to

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -33,121 +33,7 @@
 
 #ifdef CPU_MAP_ATMEGA328P // (Arduino Uno) Officially supported by Grbl.
 
-  // Define serial port pins and interrupt vectors.
-  #define SERIAL_RX     USART_RX_vect
-  #define SERIAL_UDRE   USART_UDRE_vect
-
-  // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
-  #define STEP_DDR        DDRD
-  #define STEP_PORT       PORTD
-  #define X_STEP_BIT      2  // Uno Digital Pin 2
-  #define Y_STEP_BIT      3  // Uno Digital Pin 3
-  #define Z_STEP_BIT      4  // Uno Digital Pin 4
-  #define STEP_MASK       ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)) // All step bits
-
-  // Define step direction output pins. NOTE: All direction pins must be on the same port.
-  #define DIRECTION_DDR     DDRD
-  #define DIRECTION_PORT    PORTD
-  #define X_DIRECTION_BIT   5  // Uno Digital Pin 5
-  #define Y_DIRECTION_BIT   6  // Uno Digital Pin 6
-  #define Z_DIRECTION_BIT   7  // Uno Digital Pin 7
-  #define DIRECTION_MASK    ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)) // All direction bits
-
-  // Define stepper driver enable/disable output pin.
-  #define STEPPERS_DISABLE_DDR    DDRB
-  #define STEPPERS_DISABLE_PORT   PORTB
-  #define STEPPERS_DISABLE_BIT    0  // Uno Digital Pin 8
-  #define STEPPERS_DISABLE_MASK   (1<<STEPPERS_DISABLE_BIT)
-
-  // Define homing/hard limit switch input pins and limit interrupt vectors. 
-  // NOTE: All limit bit pins must be on the same port, but not on a port with other input pins (CONTROL).
-  #define LIMIT_DDR        DDRB
-  #define LIMIT_PIN        PINB
-  #define LIMIT_PORT       PORTB
-  #define X_LIMIT_BIT      1  // Uno Digital Pin 9
-  #define Y_LIMIT_BIT      2  // Uno Digital Pin 10
-  #ifdef VARIABLE_SPINDLE // Z Limit pin and spindle enabled swapped to access hardware PWM on Pin 11.  
-    #define Z_LIMIT_BIT	   4 // Uno Digital Pin 12
-  #else
-    #define Z_LIMIT_BIT    3  // Uno Digital Pin 11
-  #endif
-  #define LIMIT_MASK       ((1<<X_LIMIT_BIT)|(1<<Y_LIMIT_BIT)|(1<<Z_LIMIT_BIT)) // All limit bits
-  #define LIMIT_INT        PCIE0  // Pin change interrupt enable pin
-  #define LIMIT_INT_vect   PCINT0_vect 
-  #define LIMIT_PCMSK      PCMSK0 // Pin change interrupt register
-
-  // Define spindle enable and spindle direction output pins.
-  #define SPINDLE_ENABLE_DDR    DDRB
-  #define SPINDLE_ENABLE_PORT   PORTB
-  // Z Limit pin and spindle PWM/enable pin swapped to access hardware PWM on Pin 11.
-  #ifdef VARIABLE_SPINDLE 
-    #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
-      // If enabled, spindle direction pin now used as spindle enable, while PWM remains on D11.
-      #define SPINDLE_ENABLE_BIT    5  // Uno Digital Pin 13 (NOTE: D13 can't be pulled-high input due to LED.)
-    #else
-      #define SPINDLE_ENABLE_BIT    3  // Uno Digital Pin 11
-    #endif
-  #else
-    #define SPINDLE_ENABLE_BIT    4  // Uno Digital Pin 12
-  #endif
-  #ifndef USE_SPINDLE_DIR_AS_ENABLE_PIN
-    #define SPINDLE_DIRECTION_DDR   DDRB
-    #define SPINDLE_DIRECTION_PORT  PORTB
-    #define SPINDLE_DIRECTION_BIT   5  // Uno Digital Pin 13 (NOTE: D13 can't be pulled-high input due to LED.)
-  #endif
-  
-  // Define flood and mist coolant enable output pins.
-  // NOTE: Uno analog pins 4 and 5 are reserved for an i2c interface, and may be installed at
-  // a later date if flash and memory space allows.
-  #define COOLANT_FLOOD_DDR   DDRC
-  #define COOLANT_FLOOD_PORT  PORTC
-  #define COOLANT_FLOOD_BIT   3  // Uno Analog Pin 3
-  #ifdef ENABLE_M7 // Mist coolant disabled by default. See config.h to enable/disable.
-    #define COOLANT_MIST_DDR   DDRC
-    #define COOLANT_MIST_PORT  PORTC
-    #define COOLANT_MIST_BIT   4 // Uno Analog Pin 4
-  #endif  
-
-  // Define user-control controls (cycle start, reset, feed hold) input pins.
-  // NOTE: All CONTROLs pins must be on the same port and not on a port with other input pins (limits).
-  #define CONTROL_DDR       DDRC
-  #define CONTROL_PIN       PINC
-  #define CONTROL_PORT      PORTC
-  #define RESET_BIT         0  // Uno Analog Pin 0
-  #define FEED_HOLD_BIT     1  // Uno Analog Pin 1
-  #define CYCLE_START_BIT   2  // Uno Analog Pin 2
-  #define SAFETY_DOOR_BIT   1  // Uno Analog Pin 1 NOTE: Safety door is shared with feed hold. Enabled by config define.
-  #define CONTROL_INT       PCIE1  // Pin change interrupt enable pin
-  #define CONTROL_INT_vect  PCINT1_vect
-  #define CONTROL_PCMSK     PCMSK1 // Pin change interrupt register
-  #define CONTROL_MASK ((1<<RESET_BIT)|(1<<FEED_HOLD_BIT)|(1<<CYCLE_START_BIT)|(1<<SAFETY_DOOR_BIT))
-  
-  // Define probe switch input pin.
-  #define PROBE_DDR       DDRC
-  #define PROBE_PIN       PINC
-  #define PROBE_PORT      PORTC
-  #define PROBE_BIT       5  // Uno Analog Pin 5
-  #define PROBE_MASK      (1<<PROBE_BIT)
-
-  
-  #ifdef VARIABLE_SPINDLE
-    // Advanced Configuration Below You should not need to touch these variables
-    #define PWM_MAX_VALUE    255.0
-    #define TCCRA_REGISTER	 TCCR2A
-    #define TCCRB_REGISTER	 TCCR2B
-    #define OCR_REGISTER     OCR2A
-
-    #define COMB_BIT	     COM2A1
-    #define WAVE0_REGISTER	 WGM20
-    #define WAVE1_REGISTER	 WGM21
-    #define WAVE2_REGISTER	 WGM22
-    #define WAVE3_REGISTER	 WGM23
-    
-    // NOTE: On the 328p, these must be the same as the SPINDLE_ENABLE settings.
-    #define SPINDLE_PWM_DDR	  DDRB
-    #define SPINDLE_PWM_PORT  PORTB
-    #define SPINDLE_PWM_BIT	  3    // Uno Digital Pin 11
-  #endif // End of VARIABLE_SPINDLE
+  #include "cpu_map_atmega328p.h"
 
 #endif
 
@@ -156,112 +42,7 @@
 
 #ifdef CPU_MAP_ATMEGA2560 // (Arduino Mega 2560) Working @EliteEng
 
-  // Serial port pins
-  #define SERIAL_RX USART0_RX_vect
-  #define SERIAL_UDRE USART0_UDRE_vect
-
-  // Increase Buffers to make use of extra SRAM
-  //#define RX_BUFFER_SIZE		256
-  //#define TX_BUFFER_SIZE		128
-  //#define BLOCK_BUFFER_SIZE	36
-  //#define LINE_BUFFER_SIZE	100
-
-  // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
-  #define STEP_DDR      DDRA
-  #define STEP_PORT     PORTA
-  #define STEP_PIN      PINA
-  #define X_STEP_BIT    2 // MEGA2560 Digital Pin 24
-  #define Y_STEP_BIT    3 // MEGA2560 Digital Pin 25
-  #define Z_STEP_BIT    4 // MEGA2560 Digital Pin 26
-  #define STEP_MASK ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)) // All step bits
-
-  // Define step direction output pins. NOTE: All direction pins must be on the same port.
-  #define DIRECTION_DDR     DDRC
-  #define DIRECTION_PORT    PORTC
-  #define DIRECTION_PIN     PINC
-  #define X_DIRECTION_BIT   7 // MEGA2560 Digital Pin 30
-  #define Y_DIRECTION_BIT   6 // MEGA2560 Digital Pin 31
-  #define Z_DIRECTION_BIT   5 // MEGA2560 Digital Pin 32
-  #define DIRECTION_MASK ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)) // All direction bits
-
-  // Define stepper driver enable/disable output pin.
-  #define STEPPERS_DISABLE_DDR   DDRB
-  #define STEPPERS_DISABLE_PORT  PORTB
-  #define STEPPERS_DISABLE_BIT   7 // MEGA2560 Digital Pin 13
-  #define STEPPERS_DISABLE_MASK (1<<STEPPERS_DISABLE_BIT)
-
-  // NOTE: All limit bit pins must be on the same port
-  #define LIMIT_DDR       DDRB
-  #define LIMIT_PORT      PORTB
-  #define LIMIT_PIN       PINB
-  #define X_LIMIT_BIT     4 // MEGA2560 Digital Pin 10
-  #define Y_LIMIT_BIT     5 // MEGA2560 Digital Pin 11
-  #define Z_LIMIT_BIT     6 // MEGA2560 Digital Pin 12
-  #define LIMIT_INT       PCIE0  // Pin change interrupt enable pin
-  #define LIMIT_INT_vect  PCINT0_vect 
-  #define LIMIT_PCMSK     PCMSK0 // Pin change interrupt register
-  #define LIMIT_MASK ((1<<X_LIMIT_BIT)|(1<<Y_LIMIT_BIT)|(1<<Z_LIMIT_BIT)) // All limit bits
-
-  // Define spindle enable and spindle direction output pins.
-  #define SPINDLE_ENABLE_DDR      DDRH
-  #define SPINDLE_ENABLE_PORT     PORTH
-  #define SPINDLE_ENABLE_BIT      3 // MEGA2560 Digital Pin 6
-  #define SPINDLE_DIRECTION_DDR   DDRE
-  #define SPINDLE_DIRECTION_PORT  PORTE
-  #define SPINDLE_DIRECTION_BIT   3 // MEGA2560 Digital Pin 5
-
-  // Define flood and mist coolant enable output pins.
-  // NOTE: Uno analog pins 4 and 5 are reserved for an i2c interface, and may be installed at
-  // a later date if flash and memory space allows.
-  #define COOLANT_FLOOD_DDR     DDRH
-  #define COOLANT_FLOOD_PORT    PORTH
-  #define COOLANT_FLOOD_BIT     5 // MEGA2560 Digital Pin 8
-  #ifdef ENABLE_M7 // Mist coolant disabled by default. See config.h to enable/disable.
-    #define COOLANT_MIST_DDR    DDRH
-    #define COOLANT_MIST_PORT   PORTH
-    #define COOLANT_MIST_BIT    6 // MEGA2560 Digital Pin 9
-  #endif  
-
-  // Define user-control CONTROLs (cycle start, reset, feed hold) input pins.
-  // NOTE: All CONTROLs pins must be on the same port and not on a port with other input pins (limits).
-  #define CONTROL_DDR       DDRK
-  #define CONTROL_PIN       PINK
-  #define CONTROL_PORT      PORTK
-  #define RESET_BIT         0  // MEGA2560 Analog Pin 8
-  #define FEED_HOLD_BIT     1  // MEGA2560 Analog Pin 9
-  #define CYCLE_START_BIT   2  // MEGA2560 Analog Pin 10
-  #define SAFETY_DOOR_BIT   3  // MEGA2560 Analog Pin 11
-  #define CONTROL_INT       PCIE2  // Pin change interrupt enable pin
-  #define CONTROL_INT_vect  PCINT2_vect
-  #define CONTROL_PCMSK     PCMSK2 // Pin change interrupt register
-  #define CONTROL_MASK ((1<<RESET_BIT)|(1<<FEED_HOLD_BIT)|(1<<CYCLE_START_BIT)|(1<<SAFETY_DOOR_BIT))
-
-  // Define probe switch input pin.
-  #define PROBE_DDR       DDRK
-  #define PROBE_PIN       PINK
-  #define PROBE_PORT      PORTK
-  #define PROBE_BIT       7  // MEGA2560 Analog Pin 15
-  #define PROBE_MASK      (1<<PROBE_BIT)
-
-  // Start of PWM & Stepper Enabled Spindle
-  #ifdef VARIABLE_SPINDLE
-    // Advanced Configuration Below You should not need to touch these variables
-    // Set Timer up to use TIMER4B which is attached to Digital Pin 7
-    #define PWM_MAX_VALUE       65535.0
-    #define TCCRA_REGISTER		TCCR4A
-    #define TCCRB_REGISTER		TCCR4B
-    #define OCR_REGISTER		OCR4B
-
-    #define COMB_BIT			COM4B1
-    #define WAVE0_REGISTER		WGM40
-    #define WAVE1_REGISTER		WGM41
-    #define WAVE2_REGISTER		WGM42
-    #define WAVE3_REGISTER		WGM43
-
-    #define SPINDLE_PWM_DDR		DDRH
-    #define SPINDLE_PWM_PORT    PORTH
-    #define SPINDLE_PWM_BIT		4 // MEGA2560 Digital Pin 97
-  #endif // End of VARIABLE_SPINDLE
+  #include "cpu_map_atmega2560.h"
 
 #endif
 
@@ -269,8 +50,9 @@
 
 /* 
 #ifdef CPU_MAP_CUSTOM_PROC
-  // For a custom pin map or different processor, copy and paste one of the default cpu map
-  // settings above and modify it to your needs. Then, make sure the defined name is also
+  // For a custom pin map or different processor, copy and edit ne of the default cpu map
+  // files above and modify it to your needs. Then, copy and paste one of the sections above
+  // and change the #defined name and included file. Make sure the defined name is also
   // changed in the config.h file.
 #endif
 */

--- a/grbl/cpu_map_atmega2560.h
+++ b/grbl/cpu_map_atmega2560.h
@@ -1,3 +1,25 @@
+/*
+  cpu_map_atmega2560.h - CPU and pin mapping configuration file
+  Part of Grbl
+
+  Copyright (c) 2012-2015 Sungeun K. Jeon
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* This cpu_map file serves as a central pin mapping settings file for AVR Mega 2560 */
+
 #ifdef GRBL_PLATFORM
 #error "cpu_map already defined: GRBL_PLATFORM=" GRBL_PLATFORM
 #endif

--- a/grbl/cpu_map_atmega2560.h
+++ b/grbl/cpu_map_atmega2560.h
@@ -1,0 +1,114 @@
+#ifdef GRBL_PLATFORM
+#error "cpu_map already defined: GRBL_PLATFORM=" GRBL_PLATFORM
+#endif
+
+#define GRBL_PLATFORM "Atmega2560"
+
+// Serial port pins
+#define SERIAL_RX USART0_RX_vect
+#define SERIAL_UDRE USART0_UDRE_vect
+
+// Increase Buffers to make use of extra SRAM
+//#define RX_BUFFER_SIZE		256
+//#define TX_BUFFER_SIZE		128
+//#define BLOCK_BUFFER_SIZE	36
+//#define LINE_BUFFER_SIZE	100
+
+// Define step pulse output pins. NOTE: All step bit pins must be on the same port.
+#define STEP_DDR      DDRA
+#define STEP_PORT     PORTA
+#define STEP_PIN      PINA
+#define X_STEP_BIT    2 // MEGA2560 Digital Pin 24
+#define Y_STEP_BIT    3 // MEGA2560 Digital Pin 25
+#define Z_STEP_BIT    4 // MEGA2560 Digital Pin 26
+#define STEP_MASK ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)) // All step bits
+
+// Define step direction output pins. NOTE: All direction pins must be on the same port.
+#define DIRECTION_DDR     DDRC
+#define DIRECTION_PORT    PORTC
+#define DIRECTION_PIN     PINC
+#define X_DIRECTION_BIT   7 // MEGA2560 Digital Pin 30
+#define Y_DIRECTION_BIT   6 // MEGA2560 Digital Pin 31
+#define Z_DIRECTION_BIT   5 // MEGA2560 Digital Pin 32
+#define DIRECTION_MASK ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)) // All direction bits
+
+// Define stepper driver enable/disable output pin.
+#define STEPPERS_DISABLE_DDR   DDRB
+#define STEPPERS_DISABLE_PORT  PORTB
+#define STEPPERS_DISABLE_BIT   7 // MEGA2560 Digital Pin 13
+#define STEPPERS_DISABLE_MASK (1<<STEPPERS_DISABLE_BIT)
+
+// Define homing/hard limit switch input pins and limit interrupt vectors. 
+// NOTE: All limit bit pins must be on the same port
+#define LIMIT_DDR       DDRB
+#define LIMIT_PORT      PORTB
+#define LIMIT_PIN       PINB
+#define X_LIMIT_BIT     4 // MEGA2560 Digital Pin 10
+#define Y_LIMIT_BIT     5 // MEGA2560 Digital Pin 11
+#define Z_LIMIT_BIT     6 // MEGA2560 Digital Pin 12
+#define LIMIT_INT       PCIE0  // Pin change interrupt enable pin
+#define LIMIT_INT_vect  PCINT0_vect 
+#define LIMIT_PCMSK     PCMSK0 // Pin change interrupt register
+#define LIMIT_MASK ((1<<X_LIMIT_BIT)|(1<<Y_LIMIT_BIT)|(1<<Z_LIMIT_BIT)) // All limit bits
+
+// Define spindle enable and spindle direction output pins.
+#define SPINDLE_ENABLE_DDR      DDRH
+#define SPINDLE_ENABLE_PORT     PORTH
+#define SPINDLE_ENABLE_BIT      3 // MEGA2560 Digital Pin 6
+#define SPINDLE_DIRECTION_DDR   DDRE
+#define SPINDLE_DIRECTION_PORT  PORTE
+#define SPINDLE_DIRECTION_BIT   3 // MEGA2560 Digital Pin 5
+
+// Define flood and mist coolant enable output pins.
+// NOTE: Uno analog pins 4 and 5 are reserved for an i2c interface, and may be installed at
+// a later date if flash and memory space allows.
+#define COOLANT_FLOOD_DDR     DDRH
+#define COOLANT_FLOOD_PORT    PORTH
+#define COOLANT_FLOOD_BIT     5 // MEGA2560 Digital Pin 8
+#ifdef ENABLE_M7 // Mist coolant disabled by default. See config.h to enable/disable.
+#define COOLANT_MIST_DDR    DDRH
+#define COOLANT_MIST_PORT   PORTH
+#define COOLANT_MIST_BIT    6 // MEGA2560 Digital Pin 9
+#endif  
+
+// Define user-control CONTROLs (cycle start, reset, feed hold) input pins.
+// NOTE: All CONTROLs pins must be on the same port and not on a port with other input pins (limits).
+#define CONTROL_DDR       DDRK
+#define CONTROL_PIN       PINK
+#define CONTROL_PORT      PORTK
+#define RESET_BIT         0  // MEGA2560 Analog Pin 8
+#define FEED_HOLD_BIT     1  // MEGA2560 Analog Pin 9
+#define CYCLE_START_BIT   2  // MEGA2560 Analog Pin 10
+#define SAFETY_DOOR_BIT   3  // MEGA2560 Analog Pin 11
+#define CONTROL_INT       PCIE2  // Pin change interrupt enable pin
+#define CONTROL_INT_vect  PCINT2_vect
+#define CONTROL_PCMSK     PCMSK2 // Pin change interrupt register
+#define CONTROL_MASK ((1<<RESET_BIT)|(1<<FEED_HOLD_BIT)|(1<<CYCLE_START_BIT)|(1<<SAFETY_DOOR_BIT))
+
+// Define probe switch input pin.
+#define PROBE_DDR       DDRK
+#define PROBE_PIN       PINK
+#define PROBE_PORT      PORTK
+#define PROBE_BIT       7  // MEGA2560 Analog Pin 15
+#define PROBE_MASK      (1<<PROBE_BIT)
+
+// Start of PWM & Stepper Enabled Spindle
+#ifdef VARIABLE_SPINDLE
+  // Advanced Configuration Below You should not need to touch these variables
+  // Set Timer up to use TIMER4B which is attached to Digital Pin 7
+  #define PWM_MAX_VALUE       65535.0
+  #define TCCRA_REGISTER		TCCR4A
+  #define TCCRB_REGISTER		TCCR4B
+  #define OCR_REGISTER		OCR4B
+  
+  #define COMB_BIT			COM4B1
+  #define WAVE0_REGISTER		WGM40
+  #define WAVE1_REGISTER		WGM41
+  #define WAVE2_REGISTER		WGM42
+  #define WAVE3_REGISTER		WGM43
+  
+  #define SPINDLE_PWM_DDR		DDRH
+  #define SPINDLE_PWM_PORT    PORTH
+  #define SPINDLE_PWM_BIT		4 // MEGA2560 Digital Pin 97
+#endif // End of VARIABLE_SPINDLE
+

--- a/grbl/cpu_map_atmega328p.h
+++ b/grbl/cpu_map_atmega328p.h
@@ -1,0 +1,122 @@
+#ifdef GRBL_PLATFORM
+#error "cpu_map already defined: GRBL_PLATFORM=" GRBL_PLATFORM
+#endif
+
+
+#define GRBL_PLATFORM "Atmega328p"
+// Define serial port pins and interrupt vectors.
+#define SERIAL_RX     USART_RX_vect
+#define SERIAL_UDRE   USART_UDRE_vect
+
+// Define step pulse output pins. NOTE: All step bit pins must be on the same port.
+#define STEP_DDR        DDRD
+#define STEP_PORT       PORTD
+#define X_STEP_BIT      2  // Uno Digital Pin 2
+#define Y_STEP_BIT      3  // Uno Digital Pin 3
+#define Z_STEP_BIT      4  // Uno Digital Pin 4
+#define STEP_MASK       ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)) // All step bits
+
+// Define step direction output pins. NOTE: All direction pins must be on the same port.
+#define DIRECTION_DDR     DDRD
+#define DIRECTION_PORT    PORTD
+#define X_DIRECTION_BIT   5  // Uno Digital Pin 5
+#define Y_DIRECTION_BIT   6  // Uno Digital Pin 6
+#define Z_DIRECTION_BIT   7  // Uno Digital Pin 7
+#define DIRECTION_MASK    ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)) // All direction bits
+
+// Define stepper driver enable/disable output pin.
+#define STEPPERS_DISABLE_DDR    DDRB
+#define STEPPERS_DISABLE_PORT   PORTB
+#define STEPPERS_DISABLE_BIT    0  // Uno Digital Pin 8
+#define STEPPERS_DISABLE_MASK   (1<<STEPPERS_DISABLE_BIT)
+
+// Define homing/hard limit switch input pins and limit interrupt vectors. 
+// NOTE: All limit bit pins must be on the same port, but not on a port with other input pins (CONTROL).
+#define LIMIT_DDR        DDRB
+#define LIMIT_PIN        PINB
+#define LIMIT_PORT       PORTB
+#define X_LIMIT_BIT      1  // Uno Digital Pin 9
+#define Y_LIMIT_BIT      2  // Uno Digital Pin 10
+#ifdef VARIABLE_SPINDLE // Z Limit pin and spindle enabled swapped to access hardware PWM on Pin 11.  
+  #define Z_LIMIT_BIT	   4 // Uno Digital Pin 12
+#else
+  #define Z_LIMIT_BIT    3  // Uno Digital Pin 11
+#endif
+#define LIMIT_MASK       ((1<<X_LIMIT_BIT)|(1<<Y_LIMIT_BIT)|(1<<Z_LIMIT_BIT)) // All limit bits
+#define LIMIT_INT        PCIE0  // Pin change interrupt enable pin
+#define LIMIT_INT_vect   PCINT0_vect 
+#define LIMIT_PCMSK      PCMSK0 // Pin change interrupt register
+
+// Define spindle enable and spindle direction output pins.
+#define SPINDLE_ENABLE_DDR    DDRB
+#define SPINDLE_ENABLE_PORT   PORTB
+// Z Limit pin and spindle PWM/enable pin swapped to access hardware PWM on Pin 11.
+#ifdef VARIABLE_SPINDLE 
+  #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
+    // If enabled, spindle direction pin now used as spindle enable, while PWM remains on D11.
+    #define SPINDLE_ENABLE_BIT    5  // Uno Digital Pin 13 (NOTE: D13 can't be pulled-high input due to LED.)
+  #else
+    #define SPINDLE_ENABLE_BIT    3  // Uno Digital Pin 11
+  #endif
+#else
+  #define SPINDLE_ENABLE_BIT    4  // Uno Digital Pin 12
+#endif
+#ifndef USE_SPINDLE_DIR_AS_ENABLE_PIN
+  #define SPINDLE_DIRECTION_DDR   DDRB
+  #define SPINDLE_DIRECTION_PORT  PORTB
+  #define SPINDLE_DIRECTION_BIT   5  // Uno Digital Pin 13 (NOTE: D13 can't be pulled-high input due to LED.)
+#endif
+  
+// Define flood and mist coolant enable output pins.
+// NOTE: Uno analog pins 4 and 5 are reserved for an i2c interface, and may be installed at
+// a later date if flash and memory space allows.
+#define COOLANT_FLOOD_DDR   DDRC
+#define COOLANT_FLOOD_PORT  PORTC
+#define COOLANT_FLOOD_BIT   3  // Uno Analog Pin 3
+#ifdef ENABLE_M7 // Mist coolant disabled by default. See config.h to enable/disable.
+  #define COOLANT_MIST_DDR   DDRC
+  #define COOLANT_MIST_PORT  PORTC
+  #define COOLANT_MIST_BIT   4 // Uno Analog Pin 4
+#endif  
+
+// Define user-control controls (cycle start, reset, feed hold) input pins.
+// NOTE: All CONTROLs pins must be on the same port and not on a port with other input pins (limits).
+#define CONTROL_DDR       DDRC
+#define CONTROL_PIN       PINC
+#define CONTROL_PORT      PORTC
+#define RESET_BIT         0  // Uno Analog Pin 0
+#define FEED_HOLD_BIT     1  // Uno Analog Pin 1
+#define CYCLE_START_BIT   2  // Uno Analog Pin 2
+#define SAFETY_DOOR_BIT   1  // Uno Analog Pin 1 NOTE: Safety door is shared with feed hold. Enabled by config define.
+#define CONTROL_INT       PCIE1  // Pin change interrupt enable pin
+#define CONTROL_INT_vect  PCINT1_vect
+#define CONTROL_PCMSK     PCMSK1 // Pin change interrupt register
+#define CONTROL_MASK ((1<<RESET_BIT)|(1<<FEED_HOLD_BIT)|(1<<CYCLE_START_BIT)|(1<<SAFETY_DOOR_BIT))
+  
+// Define probe switch input pin.
+#define PROBE_DDR       DDRC
+#define PROBE_PIN       PINC
+#define PROBE_PORT      PORTC
+#define PROBE_BIT       5  // Uno Analog Pin 5
+#define PROBE_MASK      (1<<PROBE_BIT)
+
+// Start of PWM & Stepper Enabled Spindle
+#ifdef VARIABLE_SPINDLE
+  // Advanced Configuration Below You should not need to touch these variables
+  #define PWM_MAX_VALUE    255.0
+  #define TCCRA_REGISTER	 TCCR2A
+  #define TCCRB_REGISTER	 TCCR2B
+  #define OCR_REGISTER     OCR2A
+  
+  #define COMB_BIT	     COM2A1
+  #define WAVE0_REGISTER	 WGM20
+  #define WAVE1_REGISTER	 WGM21
+  #define WAVE2_REGISTER	 WGM22
+  #define WAVE3_REGISTER	 WGM23
+      
+  // NOTE: On the 328p, these must be the same as the SPINDLE_ENABLE settings.
+  #define SPINDLE_PWM_DDR	  DDRB
+  #define SPINDLE_PWM_PORT  PORTB
+  #define SPINDLE_PWM_BIT	  3    // Uno Digital Pin 11
+#endif // End of VARIABLE_SPINDLE
+

--- a/grbl/cpu_map_atmega328p.h
+++ b/grbl/cpu_map_atmega328p.h
@@ -1,3 +1,27 @@
+/*
+  cpu_map_atmega328p.h - CPU and pin mapping configuration file
+  Part of Grbl
+
+  Copyright (c) 2012-2015 Sungeun K. Jeon
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* This cpu_map file serves as a central pin mapping settings file for AVR 328p 
+   used on the Arduino Uno */
+
+
 #ifdef GRBL_PLATFORM
 #error "cpu_map already defined: GRBL_PLATFORM=" GRBL_PLATFORM
 #endif


### PR DESCRIPTION
I found this to be easier to manage than a monolithic file when adding different configurations, and when merging with upstream changes.  It is easy to diff one platform against the next to see differences.