### PR TITLE
Attempt to add 4th axis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
 DEVICE     ?= atmega328p
+#DEVICE     ?= atmega2560
+
 CLOCK      = 16000000
 PROGRAMMER ?= -c avrisp2 -P usb
 SOURCE    = main.c motion_control.c gcode.c spindle_control.c coolant_control.c serial.c \

--- a/grbl/config.h
+++ b/grbl/config.h
@@ -39,6 +39,11 @@
 // Default cpu mappings. Grbl officially supports the Arduino Uno only. Other processor types
 // may exist from user-supplied templates or directly user-defined in cpu_map.h
 #define CPU_MAP_ATMEGA328P // Arduino Uno CPU
+#define N_AXIS 3   //3 Axis configuration. Must be compatible with DEFAULTS and CPU_MAP
+
+//#define CPU_MAP_ATMEGA2560_4AXIS // Arduino Mega CPU
+//#define N_AXIS 4   //4 Axis configuration. Must be compatible with DEFAULTS and CPU_MAP
+
 
 // Define realtime command special characters. These characters are 'picked-off' directly from the
 // serial read data stream and are not passed to the grbl line execution parser. Select characters

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -38,7 +38,6 @@
 
 #endif
 
-
 //----------------------------------------------------------------------------------------
 
 #ifdef CPU_MAP_ATMEGA2560 // (Arduino Mega 2560) Working @EliteEng
@@ -46,6 +45,17 @@
   #include "cpu_map_atmega2560.h"
 
 #endif
+
+#ifdef CPU_MAP_ATMEGA2560_4AXIS // (Arduino Mega 2560) 
+
+  #include "cpu_map_atmega2560_4axis.h"
+
+#endif
+
+#ifndef GRBL_PLATFORM
+  #error "GRBL_PLATFORM not defined.  Was valid CPU_MAP selected in config.h?"
+#endif
+
 
 //----------------------------------------------------------------------------------------
 

--- a/grbl/cpu_map_atmega2560_4axis.h
+++ b/grbl/cpu_map_atmega2560_4axis.h
@@ -1,0 +1,139 @@
+/*
+  cpu_map_atmega2560.h - CPU and pin mapping configuration file
+  Part of Grbl
+
+  Copyright (c) 2012-2015 Sungeun K. Jeon
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* This cpu_map file serves as a central pin mapping settings file for AVR Mega 2560 */
+
+#ifdef GRBL_PLATFORM
+#error "cpu_map already defined: GRBL_PLATFORM=" GRBL_PLATFORM
+#endif
+
+#define GRBL_PLATFORM "Atmega2560"
+
+// Serial port pins
+#define SERIAL_RX USART0_RX_vect
+#define SERIAL_UDRE USART0_UDRE_vect
+
+// Increase Buffers to make use of extra SRAM
+//#define RX_BUFFER_SIZE		256
+//#define TX_BUFFER_SIZE		128
+//#define BLOCK_BUFFER_SIZE	36
+//#define LINE_BUFFER_SIZE	100
+
+// Define step pulse output pins. NOTE: All step bit pins must be on the same port.
+#define STEP_DDR      DDRA
+#define STEP_PORT     PORTA
+#define STEP_PIN      PINA
+#define X_STEP_BIT    2 // MEGA2560 Digital Pin 24
+#define Y_STEP_BIT    3 // MEGA2560 Digital Pin 25
+#define Z_STEP_BIT    4 // MEGA2560 Digital Pin 26
+#define C_STEP_BIT    5 // MEGA2560 Digital Pin 27
+#define STEP_MASK ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)|(1<<C_STEP_BIT)) // All step bits
+
+// Define step direction output pins. NOTE: All direction pins must be on the same port.
+#define DIRECTION_DDR     DDRC
+#define DIRECTION_PORT    PORTC
+#define DIRECTION_PIN     PINC
+#define X_DIRECTION_BIT   7 // MEGA2560 Digital Pin 30
+#define Y_DIRECTION_BIT   6 // MEGA2560 Digital Pin 31
+#define Z_DIRECTION_BIT   5 // MEGA2560 Digital Pin 32
+#define C_DIRECTION_BIT   4 // MEGA2560 Digital Pin 33 //QUESTION: why not reverse this order?
+#define DIRECTION_MASK ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)|(1<<C_DIRECTION_BIT)) // All direction bits
+
+// Define stepper driver enable/disable output pin.
+#define STEPPERS_DISABLE_DDR   DDRB
+#define STEPPERS_DISABLE_PORT  PORTB
+#define STEPPERS_DISABLE_BIT   7 // MEGA2560 Digital Pin 13
+#define STEPPERS_DISABLE_MASK (1<<STEPPERS_DISABLE_BIT)
+
+// Define homing/hard limit switch input pins and limit interrupt vectors. 
+// NOTE: All limit bit pins must be on the same port
+#define LIMIT_DDR       DDRB
+#define LIMIT_PORT      PORTB
+#define LIMIT_PIN       PINB
+#define X_LIMIT_BIT     4 // MEGA2560 Digital Pin 10
+#define Y_LIMIT_BIT     5 // MEGA2560 Digital Pin 11
+#define Z_LIMIT_BIT     6 // MEGA2560 Digital Pin 12
+#define C_LIMIT_BIT     3 // MEGA2560 Digital Pin 50  
+#define LIMIT_INT       PCIE0  // Pin change interrupt enable pin
+#define LIMIT_INT_vect  PCINT0_vect 
+#define LIMIT_PCMSK     PCMSK0 // Pin change interrupt register
+#define LIMIT_MASK ((1<<X_LIMIT_BIT)|(1<<Y_LIMIT_BIT)|(1<<Z_LIMIT_BIT)) // All limit bits
+
+// Define spindle enable and spindle direction output pins.
+#define SPINDLE_ENABLE_DDR      DDRH
+#define SPINDLE_ENABLE_PORT     PORTH
+#define SPINDLE_ENABLE_BIT      3 // MEGA2560 Digital Pin 6
+#define SPINDLE_DIRECTION_DDR   DDRE
+#define SPINDLE_DIRECTION_PORT  PORTE
+#define SPINDLE_DIRECTION_BIT   3 // MEGA2560 Digital Pin 5
+
+// Define flood and mist coolant enable output pins.
+// NOTE: Uno analog pins 4 and 5 are reserved for an i2c interface, and may be installed at
+// a later date if flash and memory space allows.
+#define COOLANT_FLOOD_DDR     DDRH
+#define COOLANT_FLOOD_PORT    PORTH
+#define COOLANT_FLOOD_BIT     5 // MEGA2560 Digital Pin 8
+#ifdef ENABLE_M7 // Mist coolant disabled by default. See config.h to enable/disable.
+#define COOLANT_MIST_DDR    DDRH
+#define COOLANT_MIST_PORT   PORTH
+#define COOLANT_MIST_BIT    6 // MEGA2560 Digital Pin 9
+#endif  
+
+// Define user-control CONTROLs (cycle start, reset, feed hold) input pins.
+// NOTE: All CONTROLs pins must be on the same port and not on a port with other input pins (limits).
+#define CONTROL_DDR       DDRK
+#define CONTROL_PIN       PINK
+#define CONTROL_PORT      PORTK
+#define RESET_BIT         0  // MEGA2560 Analog Pin 8
+#define FEED_HOLD_BIT     1  // MEGA2560 Analog Pin 9
+#define CYCLE_START_BIT   2  // MEGA2560 Analog Pin 10
+#define SAFETY_DOOR_BIT   3  // MEGA2560 Analog Pin 11
+#define CONTROL_INT       PCIE2  // Pin change interrupt enable pin
+#define CONTROL_INT_vect  PCINT2_vect
+#define CONTROL_PCMSK     PCMSK2 // Pin change interrupt register
+#define CONTROL_MASK ((1<<RESET_BIT)|(1<<FEED_HOLD_BIT)|(1<<CYCLE_START_BIT)|(1<<SAFETY_DOOR_BIT))
+
+// Define probe switch input pin.
+#define PROBE_DDR       DDRK
+#define PROBE_PIN       PINK
+#define PROBE_PORT      PORTK
+#define PROBE_BIT       7  // MEGA2560 Analog Pin 15
+#define PROBE_MASK      (1<<PROBE_BIT)
+
+// Start of PWM & Stepper Enabled Spindle
+#ifdef VARIABLE_SPINDLE
+  // Advanced Configuration Below You should not need to touch these variables
+  // Set Timer up to use TIMER4B which is attached to Digital Pin 7
+  #define PWM_MAX_VALUE       65535.0
+  #define TCCRA_REGISTER		TCCR4A
+  #define TCCRB_REGISTER		TCCR4B
+  #define OCR_REGISTER		OCR4B
+  
+  #define COMB_BIT			COM4B1
+  #define WAVE0_REGISTER		WGM40
+  #define WAVE1_REGISTER		WGM41
+  #define WAVE2_REGISTER		WGM42
+  #define WAVE3_REGISTER		WGM43
+  
+  #define SPINDLE_PWM_DDR		DDRH
+  #define SPINDLE_PWM_PORT    PORTH
+  #define SPINDLE_PWM_BIT		4 // MEGA2560 Digital Pin 97
+#endif // End of VARIABLE_SPINDLE
+

--- a/grbl/defaults/defaults_generic.h
+++ b/grbl/defaults/defaults_generic.h
@@ -31,15 +31,19 @@
   #define DEFAULT_X_STEPS_PER_MM 250.0
   #define DEFAULT_Y_STEPS_PER_MM 250.0
   #define DEFAULT_Z_STEPS_PER_MM 250.0
+  #define DEFAULT_C_STEPS_PER_MM 250.0
   #define DEFAULT_X_MAX_RATE 500.0 // mm/min
   #define DEFAULT_Y_MAX_RATE 500.0 // mm/min
   #define DEFAULT_Z_MAX_RATE 500.0 // mm/min
+  #define DEFAULT_C_MAX_RATE 500.0 // mm/min
   #define DEFAULT_X_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
   #define DEFAULT_Y_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
   #define DEFAULT_Z_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
+  #define DEFAULT_C_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
   #define DEFAULT_X_MAX_TRAVEL 200.0 // mm
   #define DEFAULT_Y_MAX_TRAVEL 200.0 // mm
   #define DEFAULT_Z_MAX_TRAVEL 200.0 // mm
+  #define DEFAULT_C_MAX_TRAVEL 200.0 // mm
   #define DEFAULT_STEP_PULSE_MICROSECONDS 10
   #define DEFAULT_STEPPING_INVERT_MASK 0
   #define DEFAULT_DIRECTION_INVERT_MASK 0

--- a/grbl/gcode.c
+++ b/grbl/gcode.c
@@ -326,7 +326,9 @@ uint8_t gc_execute_line(char *line)
         switch(letter){
           // case 'A': // Not supported
           // case 'B': // Not supported
-          case 'C': word_bit = WORD_C; gc_block.values.xyz[C_AXIS] = value; axis_words |= (1<<C_AXIS); break;
+          #if N_AXIS == 4
+            case 'C': word_bit = WORD_C; gc_block.values.xyz[C_AXIS] = value; axis_words |= (1<<C_AXIS); break;
+          #endif
           // case 'D': // Not supported
           case 'F': word_bit = WORD_F; gc_block.values.f = value; break;
           // case 'H': // Not supported

--- a/grbl/gcode.c
+++ b/grbl/gcode.c
@@ -259,8 +259,9 @@ uint8_t gc_execute_line(char *line)
             word_bit = MODAL_GROUP_G12;
             gc_block.modal.coord_select = int_value-54; // Shift to array indexing.
             break;
-          default: FAIL(STATUS_GCODE_UNSUPPORTED_COMMAND); // [Unsupported G command]
-        }      
+          default: 
+            FAIL(STATUS_GCODE_UNSUPPORTED_COMMAND); // [Unsupported G command]
+        }
         if (mantissa > 0) { FAIL(STATUS_GCODE_COMMAND_VALUE_NOT_INTEGER); } // [Unsupported or invalid Gxx.x command]
         // Check for more than one command per modal group violations in the current block
         // NOTE: Variable 'word_bit' is always assigned, if the command is valid.
@@ -325,7 +326,7 @@ uint8_t gc_execute_line(char *line)
         switch(letter){
           // case 'A': // Not supported
           // case 'B': // Not supported
-          // case 'C': // Not supported
+          case 'C': word_bit = WORD_C; gc_block.values.xyz[C_AXIS] = value; axis_words |= (1<<C_AXIS); break;
           // case 'D': // Not supported
           case 'F': word_bit = WORD_F; gc_block.values.f = value; break;
           // case 'H': // Not supported
@@ -821,7 +822,7 @@ uint8_t gc_execute_line(char *line)
   // [0. Non-specific error-checks]: Complete unused value words check, i.e. IJK used when in arc
   // radius mode, or axis words that aren't used in the block.  
   bit_false(value_words,(bit(WORD_N)|bit(WORD_F)|bit(WORD_S)|bit(WORD_T))); // Remove single-meaning value words. 
-  if (axis_command) { bit_false(value_words,(bit(WORD_X)|bit(WORD_Y)|bit(WORD_Z))); } // Remove axis words. 
+  if (axis_command) { bit_false(value_words,(bit(WORD_X)|bit(WORD_Y)|bit(WORD_Z)|bit(WORD_C))); } // Remove axis words. 
   if (value_words) { FAIL(STATUS_GCODE_UNUSED_WORDS); } // [Unused words]
 
    

--- a/grbl/gcode.h
+++ b/grbl/gcode.h
@@ -132,6 +132,7 @@
 #define WORD_X  10
 #define WORD_Y  11
 #define WORD_Z  12
+#define WORD_C  13
 
 
 
@@ -162,7 +163,7 @@ typedef struct {
   float r;         // Arc radius
   float s;         // Spindle speed
   uint8_t t;       // Tool selection
-  float xyz[3];    // X,Y,Z Translational axes
+  float xyz[N_AXIS];    // X,Y,Z Translational axes
 } gc_values_t;
 
 

--- a/grbl/nuts_bolts.h
+++ b/grbl/nuts_bolts.h
@@ -26,7 +26,6 @@
 #define true 1
 
 // Axis array index values. Must start with 0 and be continuous.
-#define N_AXIS CONFIG_N_AXIS // Number of axes
 #define X_AXIS 0 // Axis indexing value. 
 #define Y_AXIS 1
 #define Z_AXIS 2

--- a/grbl/nuts_bolts.h
+++ b/grbl/nuts_bolts.h
@@ -26,11 +26,11 @@
 #define true 1
 
 // Axis array index values. Must start with 0 and be continuous.
-#define N_AXIS 3 // Number of axes
+#define N_AXIS CONFIG_N_AXIS // Number of axes
 #define X_AXIS 0 // Axis indexing value. 
 #define Y_AXIS 1
 #define Z_AXIS 2
-// #define A_AXIS 3
+#define C_AXIS 3
 
 // CoreXY motor assignments. DO NOT ALTER.
 // NOTE: If the A and B motor axis bindings are changed, this effects the CoreXY equations.

--- a/grbl/settings.c
+++ b/grbl/settings.c
@@ -81,15 +81,19 @@ void settings_restore_global_settings() {
   settings.steps_per_mm[X_AXIS] = DEFAULT_X_STEPS_PER_MM;
   settings.steps_per_mm[Y_AXIS] = DEFAULT_Y_STEPS_PER_MM;
   settings.steps_per_mm[Z_AXIS] = DEFAULT_Z_STEPS_PER_MM;
+  settings.steps_per_mm[C_AXIS] = DEFAULT_C_STEPS_PER_MM;
   settings.max_rate[X_AXIS] = DEFAULT_X_MAX_RATE;
   settings.max_rate[Y_AXIS] = DEFAULT_Y_MAX_RATE;
   settings.max_rate[Z_AXIS] = DEFAULT_Z_MAX_RATE;
+  settings.max_rate[C_AXIS] = DEFAULT_C_MAX_RATE;
   settings.acceleration[X_AXIS] = DEFAULT_X_ACCELERATION;
   settings.acceleration[Y_AXIS] = DEFAULT_Y_ACCELERATION;
   settings.acceleration[Z_AXIS] = DEFAULT_Z_ACCELERATION;
+  settings.acceleration[C_AXIS] = DEFAULT_C_ACCELERATION;
   settings.max_travel[X_AXIS] = (-DEFAULT_X_MAX_TRAVEL);
   settings.max_travel[Y_AXIS] = (-DEFAULT_Y_MAX_TRAVEL);
   settings.max_travel[Z_AXIS] = (-DEFAULT_Z_MAX_TRAVEL);    
+  settings.max_travel[C_AXIS] = (-DEFAULT_C_MAX_TRAVEL);    
 
   write_global_settings();
 }
@@ -307,11 +311,13 @@ void settings_init() {
 
 
 // Returns step pin mask according to Grbl internal axis indexing.
+//TODO: something like #if STEP_AXIS_ALIGNED_BASE\ return STEP_AXIS_ALIGNED_BASE<<idx);\#else existing code
 uint8_t get_step_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_STEP_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_STEP_BIT)); }
-  return((1<<Z_STEP_BIT));
+  if ( axis_idx == Z_AXIS ) { return((1<<Z_STEP_BIT)); }
+  return((1<<C_STEP_BIT));
 }
 
 
@@ -320,7 +326,8 @@ uint8_t get_direction_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_DIRECTION_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_DIRECTION_BIT)); }
-  return((1<<Z_DIRECTION_BIT));
+  if ( axis_idx == Z_AXIS ) { return((1<<Z_DIRECTION_BIT)); }
+  return((1<<C_DIRECTION_BIT));
 }
 
 
@@ -329,5 +336,6 @@ uint8_t get_limit_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_LIMIT_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_LIMIT_BIT)); }
-  return((1<<Z_LIMIT_BIT));
+  if ( axis_idx == Z_AXIS ) { return((1<<Z_LIMIT_BIT)); }
+  return((1<<C_LIMIT_BIT));
 }

--- a/grbl/settings.c
+++ b/grbl/settings.c
@@ -81,19 +81,27 @@ void settings_restore_global_settings() {
   settings.steps_per_mm[X_AXIS] = DEFAULT_X_STEPS_PER_MM;
   settings.steps_per_mm[Y_AXIS] = DEFAULT_Y_STEPS_PER_MM;
   settings.steps_per_mm[Z_AXIS] = DEFAULT_Z_STEPS_PER_MM;
-  settings.steps_per_mm[C_AXIS] = DEFAULT_C_STEPS_PER_MM;
+  #if N_AXIS == 4
+    settings.steps_per_mm[C_AXIS] = DEFAULT_C_STEPS_PER_MM;
+  #endif
   settings.max_rate[X_AXIS] = DEFAULT_X_MAX_RATE;
   settings.max_rate[Y_AXIS] = DEFAULT_Y_MAX_RATE;
   settings.max_rate[Z_AXIS] = DEFAULT_Z_MAX_RATE;
-  settings.max_rate[C_AXIS] = DEFAULT_C_MAX_RATE;
+  #if N_AXIS == 4
+    settings.max_rate[C_AXIS] = DEFAULT_C_MAX_RATE;
+  #endif
   settings.acceleration[X_AXIS] = DEFAULT_X_ACCELERATION;
   settings.acceleration[Y_AXIS] = DEFAULT_Y_ACCELERATION;
   settings.acceleration[Z_AXIS] = DEFAULT_Z_ACCELERATION;
-  settings.acceleration[C_AXIS] = DEFAULT_C_ACCELERATION;
+  #if N_AXIS == 4
+    settings.acceleration[C_AXIS] = DEFAULT_C_ACCELERATION;
+  #endif
   settings.max_travel[X_AXIS] = (-DEFAULT_X_MAX_TRAVEL);
   settings.max_travel[Y_AXIS] = (-DEFAULT_Y_MAX_TRAVEL);
   settings.max_travel[Z_AXIS] = (-DEFAULT_Z_MAX_TRAVEL);    
-  settings.max_travel[C_AXIS] = (-DEFAULT_C_MAX_TRAVEL);    
+  #if N_AXIS == 4
+    settings.max_travel[C_AXIS] = (-DEFAULT_C_MAX_TRAVEL);    
+  #endif
 
   write_global_settings();
 }
@@ -310,14 +318,49 @@ void settings_init() {
 }
 
 
+#if 1 // #This compiles smaller, and imho looks cleaner than the multi ifs. It may be faster
+uint8_t step_pin_mask_map[] = { (1<<X_STEP_BIT),
+                                (1<<Y_STEP_BIT),
+                                (1<<Z_STEP_BIT)
+                                #if N_AXIS == 4
+                                  ,(1<<C_STEP_BIT)
+                                #endif
+                                };
+uint8_t get_step_pin_mask(uint8_t axis_idx) { return step_pin_mask_map[axis_idx];}
+
+uint8_t direction_pin_mask_map[] = { (1<<X_DIRECTION_BIT),
+                                     (1<<Y_DIRECTION_BIT),
+                                     (1<<Z_DIRECTION_BIT)
+                                     #if N_AXIS == 4
+                                       ,(1<<C_DIRECTION_BIT)
+                                     #endif
+};
+uint8_t get_direction_pin_mask(uint8_t axis_idx) { return direction_pin_mask_map[axis_idx];}
+
+uint8_t limit_pin_mask_map[] = { (1<<X_LIMIT_BIT),
+                                 (1<<Y_LIMIT_BIT),
+                                 (1<<Z_LIMIT_BIT)
+                                 #if N_AXIS == 4
+                                   ,(1<<C_LIMIT_BIT)
+                                 #endif
+};
+uint8_t get_limit_pin_mask(uint8_t axis_idx) { return limit_pin_mask_map[axis_idx];}
+
+#else
+                           
 // Returns step pin mask according to Grbl internal axis indexing.
 //TODO: something like #if STEP_AXIS_ALIGNED_BASE\ return STEP_AXIS_ALIGNED_BASE<<idx);\#else existing code
 uint8_t get_step_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_STEP_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_STEP_BIT)); }
-  if ( axis_idx == Z_AXIS ) { return((1<<Z_STEP_BIT)); }
-  return((1<<C_STEP_BIT));
+  #if N_AXIS == 4
+    if ( axis_idx == Z_AXIS ) 
+  #endif 
+      return((1<<Z_STEP_BIT));
+  #if N_AXIS == 4
+    return((1<<C_STEP_BIT));
+  #endif
 }
 
 
@@ -326,8 +369,13 @@ uint8_t get_direction_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_DIRECTION_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_DIRECTION_BIT)); }
-  if ( axis_idx == Z_AXIS ) { return((1<<Z_DIRECTION_BIT)); }
-  return((1<<C_DIRECTION_BIT));
+  #if N_AXIS == 4
+  if ( axis_idx == Z_AXIS ) 
+  #endif
+   return((1<<Z_DIRECTION_BIT)); 
+  #if N_AXIS == 4
+    return((1<<C_DIRECTION_BIT));
+  #endif
 }
 
 
@@ -336,6 +384,12 @@ uint8_t get_limit_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_LIMIT_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_LIMIT_BIT)); }
-  if ( axis_idx == Z_AXIS ) { return((1<<Z_LIMIT_BIT)); }
-  return((1<<C_LIMIT_BIT));
+  #if N_AXIS == 4
+  if ( axis_idx == Z_AXIS ) 
+#endif
+     return((1<<Z_LIMIT_BIT)); 
+  #if N_AXIS == 4
+    return((1<<C_LIMIT_BIT));
+  #endif
 }
+#endif


### PR DESCRIPTION
Compiles cleanly for uno 3axis and mega 4axis.  Seems to work in simulator.
Adds 74 bytes to uno 3axis build.   Mega 4axis is 620 bytes bigger than mega 3axis.

Used 'C' for axis name, since it was my "Conveyor".  I suppose 'A' would be a better choice, that should be fairly simple search/replace.