### PR TITLE
COREXY : correction on the display function system_convert_axis_steps_to_mpos

### DIFF
--- a/grbl/system.c
+++ b/grbl/system.c
@@ -249,14 +249,14 @@ uint8_t system_execute_line(char *line)
 float system_convert_axis_steps_to_mpos(int32_t *steps, uint8_t idx)
 {
   float pos;
+  pos = steps[idx]/settings.steps_per_mm[idx];
   #ifdef COREXY
     if (idx==A_MOTOR) { 
       pos = 0.5*((steps[A_MOTOR] + steps[B_MOTOR])/settings.steps_per_mm[idx]);
-    } else { // (idx==B_MOTOR)
+    } 
+	  if (idx==B_MOTOR) { 
       pos = 0.5*((steps[A_MOTOR] - steps[B_MOTOR])/settings.steps_per_mm[idx]);
     }
-  #else
-    pos = steps[idx]/settings.steps_per_mm[idx];
   #endif
   return(pos);
 }

--- a/grbl/system.c
+++ b/grbl/system.c
@@ -254,7 +254,7 @@ float system_convert_axis_steps_to_mpos(int32_t *steps, uint8_t idx)
     if (idx==A_MOTOR) { 
       pos = 0.5*((steps[A_MOTOR] + steps[B_MOTOR])/settings.steps_per_mm[idx]);
     } 
-	  if (idx==B_MOTOR) { 
+    if (idx==B_MOTOR) { 
       pos = 0.5*((steps[A_MOTOR] - steps[B_MOTOR])/settings.steps_per_mm[idx]);
     }
   #endif


### PR DESCRIPTION
on COREXY mode, a move on X axis only display the good position on display with the <code>?</code> command. 
But a simple move on Y axis don't display the good number on Y axis. And change the value of Z axis too ...
This work fine. tested on X,Y and Z direction. 