### PR TITLE
Added support for xxx_MOTION_PURGE (e.g. to synchronize Grbl as a slave)

### DIFF
--- a/grbl/protocol.h
+++ b/grbl/protocol.h
@@ -39,6 +39,9 @@ void protocol_main_loop();
 // Checks and executes a realtime command at various stop points in main program
 void protocol_execute_realtime();
 
+// Process all pending commands and return when Grbl state is idle or alarm
+void protocol_motion_purge();
+
 // Notify the stepper subsystem to start executing the g-code program in buffer.
 // void protocol_cycle_start();
 

--- a/grbl/report.c
+++ b/grbl/report.c
@@ -140,6 +140,8 @@ void report_feedback_message(uint8_t message_code)
     printPgmString(PSTR("Pgm End")); break;
     case MESSAGE_RESTORE_DEFAULTS:
     printPgmString(PSTR("Restoring defaults")); break;
+    case MESSAGE_MOTION_PURGE:
+    printPgmString(PSTR("Motion purge")); break;
   }
   printPgmString(PSTR("]\r\n"));
 }
@@ -164,6 +166,7 @@ void report_grbl_help() {
                         "$C (check gcode mode)\r\n"
                         "$X (kill alarm lock)\r\n"
                         "$H (run homing cycle)\r\n"
+                        "- (purge queue)\r\n"
                         "~ (cycle start)\r\n"
                         "! (feed hold)\r\n"
                         "? (current status)\r\n"

--- a/grbl/serial.c
+++ b/grbl/serial.c
@@ -168,6 +168,7 @@ ISR(SERIAL_RX)
     case CMD_CYCLE_START:   bit_true_atomic(sys_rt_exec_state, EXEC_CYCLE_START); break; // Set as true
     case CMD_FEED_HOLD:     bit_true_atomic(sys_rt_exec_state, EXEC_FEED_HOLD); break; // Set as true
     case CMD_SAFETY_DOOR:   bit_true_atomic(sys_rt_exec_state, EXEC_SAFETY_DOOR); break; // Set as true
+    case CMD_MOTION_PURGE:  bit_true_atomic(sys_rt_exec_state, EXEC_MOTION_PURGE); break; // Set as true
     case CMD_RESET:         mc_reset(); break; // Call motion control reset routine.
     default: // Write character to buffer    
       next_head = serial_rx_buffer_head + 1;


### PR DESCRIPTION
A backtick in the serial input will force Grbl to purge any movement before it answers "ok". 
This is useful/needed to synchronize Grbl as a slave to another controller.
In my case a RAMPS/Marlin uses Grbl as a slave controller for 3 Z screws. I must make sure bed movement is finished before I can move the head. By default Grbl asynchronous movements makes this impossible without delays or polling on the "idle" state or Grbl.