### PR TITLE
Report receive buffer size in init message

### DIFF
--- a/grbl/report.c
+++ b/grbl/report.c
@@ -148,7 +148,11 @@ void report_feedback_message(uint8_t message_code)
 // Welcome message
 void report_init_message()
 {
-  printPgmString(PSTR("\r\nGrbl " GRBL_VERSION " ['$' for help]\r\n"));
+  printPgmString(PSTR("\r\nGrbl " GRBL_VERSION));
+  printPgmString(PSTR(" RX: ")); print_uint8_base10(RX_BUFFER_SIZE);  
+  printPgmString(PSTR(" ['$' for help]\r\n"));
+
+  printPgmString(PSTR("\r\n"));
 }
 
 // Grbl help message


### PR DESCRIPTION
This will allow clients to compute remaining buffer size when streaming gcode while a non default receive buffer size is used