### PR TITLE
Invert flag for coolant output

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -172,6 +172,9 @@
 // uncomment the config option USE_SPINDLE_DIR_AS_ENABLE_PIN below.
 // #define INVERT_SPINDLE_ENABLE_PIN // Default disabled. Uncomment to enable.
 
+// Inverts the coolant output
+#define INVERT_COOLANT_ENABLE_PIN
+
 // Enable control pin states feedback in status reports. The data is presented as simple binary of
 // the control pin port (0 (low) or 1(high)), masked to show only the input pins. Non-control pins on the 
 // port will always show a 0 value. See cpu_map.h for the pin bitmap. As with the limit pin reporting,

--- a/grbl/coolant_control.c
+++ b/grbl/coolant_control.c
@@ -33,9 +33,18 @@ void coolant_init()
 
 void coolant_stop()
 {
-  COOLANT_FLOOD_PORT &= ~(1 << COOLANT_FLOOD_BIT);
+  #ifdef INVERT_COOLANT_ENABLE_PIN
+    COOLANT_FLOOD_PORT |= (1<<COOLANT_FLOOD_BIT);
+  #else
+    COOLANT_FLOOD_PORT &= ~(1<<COOLANT_FLOOD_BIT);
+  #endif
+  
   #ifdef ENABLE_M7
-    COOLANT_MIST_PORT &= ~(1 << COOLANT_MIST_BIT);
+    #ifdef INVERT_COOLANT_ENABLE_PIN
+      COOLANT_MIST_PORT |= (1<<COOLANT_MIST_BIT);
+    #else
+      COOLANT_MIST_PORT &= ~(1<<COOLANT_MIST_BIT);
+    #endif
   #endif
 }
 
@@ -43,11 +52,21 @@ void coolant_stop()
 void coolant_set_state(uint8_t mode)
 {
   if (mode == COOLANT_FLOOD_ENABLE) {
-    COOLANT_FLOOD_PORT |= (1 << COOLANT_FLOOD_BIT);
+	  
+    #ifdef INVERT_COOLANT_ENABLE_PIN
+      COOLANT_FLOOD_PORT &= ~(1<<COOLANT_FLOOD_BIT);
+    #else
+      COOLANT_FLOOD_PORT |= (1<<COOLANT_FLOOD_BIT);
+    #endif
 
   #ifdef ENABLE_M7  
     } else if (mode == COOLANT_MIST_ENABLE) {
-      COOLANT_MIST_PORT |= (1 << COOLANT_MIST_BIT);
+		
+	  #ifdef INVERT_COOLANT_ENABLE_PIN
+        COOLANT_MIST_PORT &= ~(1<<COOLANT_MIST_BIT);
+      #else
+        COOLANT_MIST_PORT |= (1<<COOLANT_MIST_BIT);
+      #endif
   #endif
 
   } else {


### PR DESCRIPTION
Added a config option to invert the coolant output pin(s). This matches the existing config flag for inverting the spindle enable pin.