### PR TITLE
Adding servo control using variable spindle.

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -270,6 +270,25 @@
 // this D13 LED toggling should go away. We haven't tested this though. Please report how it goes!
 // #define USE_SPINDLE_DIR_AS_ENABLE_PIN // Default disabled. Uncomment to enable.
 
+// Use variable spindle output to control a servo motor. Variying the spindle RPM will vary the servo position
+// where SPINDLE_MIN_RPM would be the minimun and SPINDLE_MAX_RPM would be the maximum position respectively.
+// What the min and max position are for the servo can be controlled with parameters SERVO_MIN_PULSE_WIDTH
+// and SERVO_MAX_PULSE_WIDTH defined bellow. The default values work for a common HXT-900. Movemennt direction
+// can be inverted using INVERT_SERVO_ENABLE.
+#define SPINDLE_SERVO_CONTROL
+
+// Used by the SPINDLE_SERVO_CONTROL only.
+#ifdef SPINDLE_SERVO_CONTROL
+  // SERVO_MIN_PULSE_WIDTH determines minimun position for servo.
+  // Default 500 value should work for most servos.
+  #define SERVO_MIN_PULSE_WIDTH 500
+  // SERVO_MAX_PULSE WIDTH determines maximun position for servo.
+  // default 2000 value should work for most servos.
+  #define SERVO_MAX_PULSE_WIDTH 2000
+  // Invert servo movement direction
+  // #define INVERT_SERVO_ENABLE
+#endif
+
 // With this enabled, Grbl sends back an echo of the line it has received, which has been pre-parsed (spaces
 // removed, capitalized letters, no comments) and is to be immediately executed by Grbl. Echoes will not be 
 // sent upon a line buffer overflow, but should for all normal lines sent to Grbl. For example, if a user 
@@ -405,6 +424,10 @@
 
 #if defined(USE_SPINDLE_DIR_AS_ENABLE_PIN) && !defined(CPU_MAP_ATMEGA328P)
   #error "USE_SPINDLE_DIR_AS_ENABLE_PIN may only be used with a 328p processor"
+#endif
+
+#if defined(SPINDLE_SERVO_CONTROL) && defined(MINIMUM_SPINDLE_PWM)
+  #error "MINIMUM_SPINDLE_PWM can't be used with SPINDLE_SERVO_CONTROL"
 #endif
 
 // ---------------------------------------------------------------------------------------

--- a/grbl/spindle_control.c
+++ b/grbl/spindle_control.c
@@ -17,10 +17,24 @@
 
   You should have received a copy of the GNU General Public License
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+
+  PWM modification for RC Servo based on https://github.com/robottini/grbl-servo
+  Using 1/1024 prescaler to lower PWM frequency to 61Hz
+  Having 16 milli sec period / 256 steps = 64 micro sec/step
 */
 
 #include "grbl.h"
 
+#ifdef SPINDLE_SERVO_CONTROL
+  // Set prescaler to 1/1024
+  #define PRE_SCALER 0x07
+  #define MICROSEC_PER_STEP 64
+  #define SERVO_MIN_PULSE (SERVO_MIN_PULSE_WIDTH / MICROSEC_PER_STEP)
+  #define SERVO_MAX_PULSE (SERVO_MAX_PULSE_WIDTH / MICROSEC_PER_STEP)
+#else
+  // Set prescaler to 1/8
+  #define PRE_SCALER 0x02
+#endif
 
 void spindle_init()
 {    
@@ -47,7 +61,15 @@ void spindle_stop()
 {
   // On the Uno, spindle enable and PWM are shared. Other CPUs have seperate enable pin.
   #ifdef VARIABLE_SPINDLE
-    TCCRA_REGISTER &= ~(1<<COMB_BIT); // Disable PWM. Output voltage is zero.
+    #ifdef SPINDLE_SERVO_CONTROL
+      #ifdef INVERT_SERVO_ENABLE
+        OCR_REGISTER = SERVO_MAX_PULSE;
+      #else
+        OCR_REGISTER = SERVO_MIN_PULSE;
+      #endif
+    #else
+      TCCRA_REGISTER &= ~(1<<COMB_BIT); // Disable PWM. Output voltage is zero.
+    #endif
     #if defined(CPU_MAP_ATMEGA2560) || defined(USE_SPINDLE_DIR_AS_ENABLE_PIN)
       #ifdef INVERT_SPINDLE_ENABLE_PIN
         SPINDLE_ENABLE_PORT |= (1<<SPINDLE_ENABLE_BIT);  // Set pin to high
@@ -86,12 +108,12 @@ void spindle_set_state(uint8_t state, float rpm)
       // TODO: Install the optional capability for frequency-based output for servos.
       #ifdef CPU_MAP_ATMEGA2560
       	TCCRA_REGISTER = (1<<COMB_BIT) | (1<<WAVE1_REGISTER) | (1<<WAVE0_REGISTER);
-        TCCRB_REGISTER = (TCCRB_REGISTER & 0b11111000) | 0x02 | (1<<WAVE2_REGISTER) | (1<<WAVE3_REGISTER); // set to 1/8 Prescaler
+        TCCRB_REGISTER = (TCCRB_REGISTER & 0b11111000) | PRE_SCALER | (1<<WAVE2_REGISTER) | (1<<WAVE3_REGISTER); // set to prescaler
         OCR4A = 0xFFFF; // set the top 16bit value
         uint16_t current_pwm;
       #else
         TCCRA_REGISTER = (1<<COMB_BIT) | (1<<WAVE1_REGISTER) | (1<<WAVE0_REGISTER);
-        TCCRB_REGISTER = (TCCRB_REGISTER & 0b11111000) | 0x02; // set to 1/8 Prescaler
+        TCCRB_REGISTER = (TCCRB_REGISTER & 0b11111000) | PRE_SCALER; // set prescaler
         uint8_t current_pwm;
       #endif
 
@@ -104,6 +126,14 @@ void spindle_set_state(uint8_t state, float rpm)
           if ( rpm > SPINDLE_RPM_RANGE ) { rpm = SPINDLE_RPM_RANGE; } // Prevent integer overflow
         }
         current_pwm = floor( rpm*(PWM_MAX_VALUE/SPINDLE_RPM_RANGE) + 0.5);
+        #ifdef SPINDLE_SERVO_CONTROL
+          #define SERVO_PULSE_RANGE (SERVO_MAX_PULSE - SERVO_MIN_PULSE)
+          #ifdef INVERT_SERVO_ENABLE
+            current_pwm = floor(SERVO_MAX_PULSE - current_pwm * (SERVO_PULSE_RANGE/PWM_MAX_VALUE));
+          #else
+            current_pwm = floor(SERVO_MIN_PULSE + current_pwm * (SERVO_PULSE_RANGE/PWM_MAX_VALUE));
+          #endif
+        #endif
         #ifdef MINIMUM_SPINDLE_PWM
           if (current_pwm < MINIMUM_SPINDLE_PWM) { current_pwm = MINIMUM_SPINDLE_PWM; }
         #endif
@@ -118,7 +148,6 @@ void spindle_set_state(uint8_t state, float rpm)
           #endif
         #endif
       }
-      
     #else
       // NOTE: Without variable spindle, the enable bit should just turn on or off, regardless
       // if the spindle speed value is zero, as its ignored anyhow.      


### PR DESCRIPTION
Defined new symbol SPINDLE_SERVO_CONTROL on config.h that when defined
will cause the prescaler for PWM on pin 11 to be set to 1/1024 instead
of the original 1/8 bringing PWM freq down to 61Hz.

Defined configuration values:
- SERVO_MIN_PULSE_WIDTH
- SERVO_MAX_PULSE_WIDTH

and symbol:
- INVERT_SERVO_ENABLE

Than can be used to configure the servo movement range and direction.
Restrict SPINDLE_SERVO_CONTROL and MINIMUM_SPINDLE_PWM enabled at the
same time.