### PR TITLE
config.c: use STATUS_OK in status_code comparation

### DIFF
--- a/grbl/report.c
+++ b/grbl/report.c
@@ -39,7 +39,7 @@
 // TODO: Install silent mode to return only numeric values, primarily for GUIs.
 void report_status_message(uint8_t status_code) 
 {
-  if (status_code == 0) { // STATUS_OK
+  if (status_code == STATUS_OK) { // STATUS_OK
     printPgmString(PSTR("ok\r\n"));
   } else {
     printPgmString(PSTR("error: "));


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>