### PR TITLE
Amend config.h comments to hint at configurable control pin inversions

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -153,6 +153,9 @@
 
 // Inverts pin logic of the control command pins. This essentially means when this option is enabled
 // you can use normally-closed switches, rather than the default normally-open switches.
+// As of v0.9, you can invert specific control pin groups from the serial interface.  See the v0.9 wiki
+// for more information.
+//
 // NOTE: If you require individual control pins inverted, keep this macro disabled and simply alter
 //   the CONTROL_INVERT_MASK definition in cpu_map.h files.
 // #define INVERT_ALL_CONTROL_PINS // Default disabled. Uncomment to enable.


### PR DESCRIPTION
This PR adds an extra sentence to the config.h that indicates that inverting control pins can be done from the serial interface.  I somehow didn't notice this in the documentation until @chamnit said it was possible, so I wanted to put a hint in in case anyone else was similarly confused and did not find the reference to inverting control pin logic from the wiki.