### PR TITLE
Fix 16 dependency issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ OBJECTS = $(addprefix $(BUILDDIR)/,$(notdir $(SOURCE:.c=.o)))
 # symbolic targets:
 all:	grbl.hex
 
-$(BUILDDIR)/%.o: $(SOURCEDIR)/%.c
+$(BUILDDIR)/%.o: $(SOURCEDIR)/%.c $(SOURCEDIR)/*.h $(SOURCEDIR)/cpu_map/cpu_map_atmega328p.h $(SOURCEDIR)/defaults/defaults_generic.h
 	$(COMPILE) -MMD -MP -c $< -o $@
 
 .S.o:


### PR DESCRIPTION
Hi, I've fixed 16 missing dependencies reported.
Those issues can cause incorrect results when grbl is incrementally built.
For example, any changes in "grbl/coolant_control.h" will not cause "build/settings.o" to be rebuilt, which is incorrect. The dependency issue in line 52 of Makefile causes the incorrect build results of 16 targets, including "build/settings.o", build/gcode.o", "build/system.o" and etc.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake