### PR TITLE
Rewrite Makefile to resolve dependency issues reported by Vemake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,10 @@ OBJECTS = $(addprefix $(BUILDDIR)/,$(notdir $(SOURCE:.c=.o)))
 all:	grbl.hex
 
 $(BUILDDIR)/%.o: $(SOURCEDIR)/%.c
-	$(COMPILE) -MMD -MP -c $< -o $@
+	$(COMPILE) -c $< -o $@
+
+$(BUILDDIR)/%.d: $(SOURCEDIR)/%.c
+	$(COMPILE) -MM -MT"$@ $(@:.d=.o)" -MP -MF $@ $<
 
 .S.o:
 	$(COMPILE) -x assembler-with-cpp -c $< -o $(BUILDDIR)/$@


### PR DESCRIPTION
Hi, we found **one** redundant dependence and **16** missing dependencies in the Makefile.

The **eeprom.o** depends on **eeprom.c** but no other headers specified in the Makefile. 
 
We have rewritten the Makefile to take the input from the .d files generated from [Auto Dependency Generation](http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/). 

Please have a look. 

This PR also fix missing dependencies reported in https://github.com/grbl/grbl/pull/1537

Thanks